### PR TITLE
Proof of concept: native prototype of `AsyncContext` proposal using existing `v8::Context` methods

### DIFF
--- a/.github/workflows/docker-test.sh
+++ b/.github/workflows/docker-test.sh
@@ -1,0 +1,15 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run AsyncContext tests with benjamn/deno:async-context Docker image
+      run: docker/tests/docker-run.sh benjamn/deno:async-context

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,7 +1,7 @@
 {
   "require": "@esbuild-kit/cjs-loader",
   "loader": "@esbuild-kit/esm-loader",
-  "spec": ["tests/**"],
+  "spec": ["tests/*.test.ts"],
   "extensions": ["ts"],
   "watch-files": ["src"],
   "node-option": ["no-warnings"]

--- a/tests/docker-native/docker-run.sh
+++ b/tests/docker-native/docker-run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd $(dirname $0)
+
+DENO_IMAGE=${1:-benjamn/deno:async-context}
+echo "Running tests using $DENO_IMAGE"
+
+# Try changing :async-context to :unmodified to observe the tests fail, most
+# immediately because AsyncContext is not defined globally.
+exec docker run -v $(pwd):/deno --rm $DENO_IMAGE test --allow-read --trace-ops *.ts

--- a/tests/docker-native/polyfillable.ts
+++ b/tests/docker-native/polyfillable.ts
@@ -1,0 +1,254 @@
+// These tests were directly adapted from ../async-context.test.ts, with
+// different imports and no Promise.prototype.then wrapping. These tests are
+// "polyfillable" in the sense that they could pass using a polyfill
+// implementation like the one from PR #14, but no polyfill is needed when the
+// tests are executed using benjamn/deno:async-context.
+
+import * as assert from "https://deno.land/std@0.173.0/node/assert.ts";
+import { describe, it } from "https://deno.land/std@0.173.0/testing/bdd.ts";
+
+type Value = { id: number };
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("sync", () => {
+  describe("run and get", () => {
+    it("has initial undefined state", () => {
+      const ctx = new AsyncContext<Value>();
+
+      const actual = ctx.get();
+
+      assert.equal(actual, undefined);
+    });
+
+    it("return value", () => {
+      const ctx = new AsyncContext<Value>();
+      const expected = { id: 1 };
+
+      const actual = ctx.run({ id: 2 }, () => expected);
+
+      assert.equal(actual, expected);
+    });
+
+    it("get returns current context value", () => {
+      const ctx = new AsyncContext<Value>();
+      const expected = { id: 1 };
+
+      const actual = ctx.run(expected, () => ctx.get());
+
+      assert.equal(actual, expected);
+    });
+
+    it("get within nesting contexts", () => {
+      const ctx = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+
+      const actual = ctx.run(first, () => {
+        return [ctx.get(), ctx.run(second, () => ctx.get()), ctx.get()];
+      });
+
+      assert.deepStrictEqual(actual, [first, second, first]);
+    });
+
+    it("get within nesting different contexts", () => {
+      const a = new AsyncContext<Value>();
+      const b = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+
+      const actual = a.run(first, () => {
+        return [
+          a.get(),
+          b.get(),
+          ...b.run(second, () => [a.get(), b.get()]),
+          a.get(),
+          b.get(),
+        ];
+      });
+
+      assert.deepStrictEqual(actual, [
+        first,
+        undefined,
+        first,
+        second,
+        first,
+        undefined,
+      ]);
+    });
+  });
+
+  describe("wrap", () => {
+    it("stores initial undefined state", () => {
+      const ctx = new AsyncContext<Value>();
+      const wrapped = AsyncContext.wrap(() => ctx.get());
+
+      const actual = ctx.run({ id: 1 }, () => wrapped());
+
+      assert.equal(actual, undefined);
+    });
+
+    it("stores current state", () => {
+      const ctx = new AsyncContext<Value>();
+      const expected = { id: 1 };
+
+      const wrapped = ctx.run(expected, () => {
+        return AsyncContext.wrap(() => ctx.get());
+      });
+
+      const actual = wrapped();
+
+      assert.equal(actual, expected);
+    });
+
+    it("wrap within nesting contexts", () => {
+      const ctx = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+
+      const actual = ctx.run(first, () => {
+        const wrapped = ctx.run(second, () => {
+          return AsyncContext.wrap(() => ctx.get());
+        });
+        return [ctx.get(), wrapped(), ctx.get()];
+      });
+
+      assert.deepStrictEqual(actual, [first, second, first]);
+    });
+
+    it("wrap out of order", () => {
+      const ctx = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+
+      const firstWrap = ctx.run(first, () => {
+        return AsyncContext.wrap(() => ctx.get());
+      });
+      const secondWrap = ctx.run(second, () => {
+        return AsyncContext.wrap(() => ctx.get());
+      });
+      const actual = [firstWrap(), secondWrap(), firstWrap(), secondWrap()];
+
+      assert.deepStrictEqual(actual, [first, second, first, second]);
+    });
+  });
+});
+
+describe("async via promises", () => {
+  // beforeEach(() => {
+  //   Promise.prototype.then = then;
+  // });
+  // afterEach(() => {
+  //   Promise.prototype.then = nativeThen;
+  // });
+
+  describe("run and get", () => {
+    it("get returns current context value", async () => {
+      const ctx = new AsyncContext<Value>();
+      const expected = { id: 1 };
+
+      const actual = await ctx.run(expected, () => {
+        return Promise.resolve().then(() => ctx.get());
+      });
+
+      assert.equal(actual, expected);
+    });
+
+    it("get within nesting contexts", async () => {
+      const ctx = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+
+      const actual = await ctx.run(first, () => {
+        return Promise.resolve<Value[]>([])
+          .then((temp) => {
+            temp.push(ctx.get());
+            return temp;
+          })
+          .then((temp) => {
+            return ctx.run(second, () => {
+              return Promise.resolve().then(() => {
+                temp.push(ctx.get());
+                return temp;
+              });
+            });
+          })
+          .then((temp) => {
+            temp.push(ctx.get());
+            return temp;
+          });
+      });
+
+      assert.deepStrictEqual(actual, [first, second, first]);
+    });
+
+    it("get within nesting different contexts", async () => {
+      const a = new AsyncContext<Value>();
+      const b = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+
+      const actual = await a.run(first, () => {
+        return Promise.resolve<Value[]>([])
+          .then((temp) => {
+            temp.push(a.get(), b.get());
+            return temp;
+          })
+          .then((temp) => {
+            return b.run(second, () => {
+              return Promise.resolve().then(() => {
+                temp.push(a.get(), b.get());
+                return temp;
+              });
+            });
+          })
+          .then((temp) => {
+            temp.push(a.get(), b.get());
+            return temp;
+          });
+      });
+
+      assert.deepStrictEqual(actual, [
+        first,
+        undefined,
+        first,
+        second,
+        first,
+        undefined,
+      ]);
+    });
+
+    it("get out of order", async () => {
+      const ctx = new AsyncContext<Value>();
+      const first = { id: 1 };
+      const second = { id: 2 };
+
+      const firstRun = ctx.run(first, () => {
+        return [
+          sleep(10).then(() => ctx.get()),
+          sleep(20).then(() => ctx.get()),
+          sleep(30).then(() => ctx.get()),
+        ];
+      });
+      const secondRun = ctx.run(second, () => {
+        return [
+          sleep(25).then(() => ctx.get()),
+          sleep(15).then(() => ctx.get()),
+          sleep(5).then(() => ctx.get()),
+        ];
+      });
+
+      const actual = await Promise.all(firstRun.concat(secondRun));
+
+      assert.deepStrictEqual(actual, [
+        first,
+        first,
+        first,
+        second,
+        second,
+        second,
+      ]);
+    });
+  });
+});

--- a/tests/docker-native/unpolyfillable.ts
+++ b/tests/docker-native/unpolyfillable.ts
@@ -1,0 +1,28 @@
+import * as assert from "https://deno.land/std@0.173.0/node/assert.ts";
+import { describe, it } from "https://deno.land/std@0.173.0/testing/bdd.ts";
+
+describe("async via native async/await", () => {
+  it("works after awaited setTimeout result", async () => {
+    const ctx = new AsyncContext<number>();
+    const ctxRunResult = await ctx.run(1234, async () => {
+      assert.strictEqual(ctx.get(), 1234);
+      const setTimeoutResult = await ctx.run(
+        2345,
+        () => new Promise(resolve => {
+          setTimeout(() => resolve(ctx.get()), 20);
+        }),
+      );
+      assert.strictEqual(setTimeoutResult, 2345);
+      assert.strictEqual(ctx.get(), 1234);
+      return "final result";
+    }).then(result => {
+      assert.strictEqual(result, "final result");
+      // The code that generated the Promise has access to the 1234 value
+      // provided to ctx.run above, but consumers of the Promise do not
+      // automatically inherit it.
+      assert.strictEqual(ctx.get(), void 0);
+      return "ctx.run result 👋";
+    });
+    assert.strictEqual(ctxRunResult, "ctx.run result 👋");
+  });
+});


### PR DESCRIPTION
Hello @legendecas, @jridgewell, and other interested parties!

First of all, this proposal has my enthusiastic support, even/especially in its current, relatively minimal form. I’d love to talk about the kinds of context systems that can be built on this foundation, but that’s a topic for another thread.

In case this is helpful for your demonstration purposes, I wanted to let you know about a fully functional[^please-check-this] native implementation of `AsyncContext` that I’ve published as a cross-platform Docker image: [benjamn/deno:async-context](https://github.com/benjamn/deno/pull/2). Of course, if you already have your own native implementation strategy, I’d love to see how it works and compare notes.

[^please-check-this]: I believe this implementation is complete and correct at the moment, but I would encourage you to play with it yourselves before recommending it to others, just in case I’m missing something.

If you have [Docker](https://docs.docker.com/get-docker/) installed, you can fire up a REPL where `AsyncContext` is defined using the following command:
```sh
docker run -it --rm benjamn/deno:async-context repl

# Alternatively, for improved 'thenables' support:
docker run -it --rm benjamn/deno:async-thenables repl
```
You can also build the project from source, but that takes much longer (>60min on a late model Intel Macbook pro), mostly because V8 has to be built from source, even though I am not modifying the V8 source in any way. [The scripts used to build the Docker image](https://github.com/benjamn/deno/tree/subtext-ideas/docker) are probably the best reference for how to build it locally, if you prefer that route.

Thanks to the way this implementation hooks into the creation and execution of `PromiseReactionJob` objects, native `async`/`await` and `Promise` code like this automatically works, with no modifications to `Promise.prototype.then`:
```ts
const ctx = new AsyncContext;
ctx.run(1234, async () => {
  console.log("before await", ctx.get());
  const setTimeoutResult = await ctx.run(
    2345,
    () => new Promise(resolve => {
      setTimeout(() => resolve(ctx.get()), 20);
    }),
  );
  console.log("after await", ctx.get());
  console.log({ setTimeoutResult });
  return "final result";
}).then(result => {
  console.log("final result?", result);
  console.log("outside ctx.run", ctx.get());
})
```
This prints
```
before await 1234
Promise { <pending> }
> after await 1234
{ setTimeoutResult: 2345 }
final result? final result
outside ctx.run undefined
```
I adapted the existing tests from this repository [here](https://github.com/legendecas/proposal-async-context/blob/536cfb8f9e247a2d3dd7e3f4a30f3401d4c30283/tests/docker-native/polyfillable.ts). After some predictable adjustments to the `import`s and removing the `Promise.prototype.then` wrapping code, those tests are all [passing](https://github.com/benjamn/deno/actions/runs/3981265741/jobs/6824883487). This PR also contains a version of this Docker-powered native test suite, in case you want to try [adding your own tests](https://github.com/legendecas/proposal-async-context/pull/17/files#r1084263767) (feel free to push to my branch).[^workflow-approval]

[^workflow-approval]: One of the maintainers may need to approve/enable the `.github/workflows/docker-test.sh` workflow to allow it to run for this PR.

As a bonus, `setTimeout` and `setInterval` in this implementation use `AsyncContext.wrap` for their callbacks to achieve `AsyncContext` preservation. This is a good example of how the host environment can work with `AsyncContext` when implementing its own runtime APIs (like `setTimeout`) that are not part of the ECMAScript specification.

I realize it’s way too early in the [TC39 proposal process](https://tc39.es/process-document/) to commit to any specific implementation details, but this is a subtle proposal, and many of the interested parties bring intuitions from previous systems with similar goals but slightly different concrete usage, semantics, pitfalls, etc. I hope this native implementation allows those folks to check their intuitions thoroughly, especially in scenarios where the desired flow of `AsyncContext` could be broken. When you no longer have to keep in mind the limitations of the `Promise.prototype.then` polyfill from #14, it's easier to appreciate the unification of synchronous and asynchronous context management that this proposal allows.

As I explained in https://github.com/benjamn/deno/pull/2, I’m using Deno because it’s a V8-based runtime that does not already have the context-like functionality Node.js has been adding with `async_hooks`. I imagine the Node.js implementation of `AsyncContext` will attempt to use or interoperate with `async_hooks`, but I wanted to show you don’t need that foundation; hence Deno. All you need is a way to hook into `PromiseReactionJob` creation/execution, which V8 already provides via [two existing methods of `v8::Context`](https://github.com/v8/v8/blob/10.9.194.4/src/api/api.cc#L6709-L6725), introduced in [this cryptic/convenient V8 pull request](https://chromium-review.googlesource.com/c/v8/v8/+/2005849) back in March 2020.

Please let me know if you run into any snags with this implementation, or you have any other questions or suggestions for improvement. Looking forward to your presentation next week!