### PR TITLE
Allow Symbol to be used as name property in wrapped function

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -412,7 +412,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
                 1. Set _L_ to _targetLenAsInt_.
           1. Perform SetFunctionLength(_F_, _L_).
           1. Let _targetName_ be ? Get(_target_, *"name"*).
-          1. If _targetName_ is not a String, set _targetName_ to the empty String.
+          1. If _targetName_ is not a String or a Symbol, set _targetName_ to the empty String.
           1. Perform SetFunctionName(_F_, _targetName_, *"wrapped"*).
           1. Return _F_.
         </emu-alg>


### PR DESCRIPTION
It is legal to use `Symbol` as the function name - https://tc39.es/ecma262/#sec-setfunctionname

```js
const f = Symbol('myfn');

const obj = { [f]: () => {} }
console.log(obj[f].name); // [myfn]

const alias = obj[f];
console.log(alias.name); // [myfn]

function newFn() {}
newFn.name = `wrapped${obj[f].name}`; // wrapped[myfn]
```