### PR TITLE
Add missing return to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ const scheduler = {
   postTask(task, options) {
     // In practice, the task execution may be deferred.
     // Here we simply run the task immediately with the context.
-    this.context.run({ priority: options.priority }, task);
+    return this.context.run({ priority: options.priority }, task);
   },
   currentTask() {
     return this.context.get() ?? { priority: "default" };


### PR DESCRIPTION
based on this code below with `await` we're expecting to return a value here:

```typescript
const res = await scheduler.postTask(task, { priority: "background" });
```