### PR TITLE
Add AsyncContext namespace and Snapshot and Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ namespace AsyncContext {
 
     get name(): string;
 
-    run<R>(value: T, fn: () => R): R;
+    run<R>(value: T, fn: (...args: any[])=> R, ...args: any[]): R;
 
     get(): T | undefined;
   }

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ interface AsyncLocalOptions<T> {
 class AsyncSnapshot {
   constructor();
 
-  run<R>(fn: (...args: any[]) => R, ...args: any[]): R;
+  restore<R>(fn: (...args: any[]) => R, ...args: any[]): R;
 }
 ```
 
@@ -225,7 +225,7 @@ function main() {
     // The snapshotDuringTop will restore all AsyncLocal to their snapshot
     // state and invoke the wrapped function. We pass a function which it will
     // invoke.
-    snapshotDuringTop.run(() => {
+    snapshotDuringTop.restore(() => {
       // Despite being lexically nested inside 'C', the snapshot restored us to
       // to the 'top' state.
       console.log(local.get()); // => 'top'
@@ -249,7 +249,7 @@ export function enqueueCallback(cb: () => void) {
   // Each callback is stored with the context at which it was enqueued.
   const snapshot = new AsyncSnapshot();
   queue.push(() => {
-    snapshot.run(cb);
+    snapshot.restore(cb);
   });
 }
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Non-goals:
 
 # Proposed Solution
 
-`AsyncContext.Variable` are designed as a value store for context propagation across
+`AsyncContext` are designed as a value store for context propagation across
 logically-connected sync/async code execution.
 
 ```typescript
@@ -178,12 +178,12 @@ namespace AsyncContext {
 }
 ```
 
-`AsyncContext.Variable.prototype.run()` and `AsyncContext.Variable.prototype.get()` sets and gets
-the current value of an async execution flow. `AsyncContext.Snapshot` allows you
-to opaquely capture the current value of all `AsyncContext.Variable`s and execute a
+`Variable.prototype.run()` and `Variable.prototype.get()` sets and gets
+the current value of an async execution flow. `Snapshot` allows you
+to opaquely capture the current value of all `Variable`s and execute a
 function at a later time with as if those values were still the current values
-(a snapshot and restore). Note that even with `AsyncContext.Snapshot`, you can
-only access the value associated with an `AsyncContext.Variable` instance if you have
+(a snapshot and restore). Note that even with `Snapshot`, you can
+only access the value associated with an `Variable` instance if you have
 access to that instance.
 
 ```typescript
@@ -240,7 +240,7 @@ function randomTimeout() {
 }
 ```
 
-`AsyncContext.Snapshot` is useful for implementing APIs that logically "schedule" a
+`Snapshot` is useful for implementing APIs that logically "schedule" a
 callback, so the callback will be called with the context that it logically
 belongs to, regardless of the context under which it actually runs:
 
@@ -250,9 +250,7 @@ let queue = [];
 export function enqueueCallback(cb: () => void) {
   // Each callback is stored with the context at which it was enqueued.
   const snapshot = new AsyncContext.Snapshot();
-  queue.push(() => {
-    snapshot.restore(cb);
-  });
+  queue.push(() => snapshot.restore(cb));
 }
 
 runWhenIdle(() => {
@@ -266,7 +264,7 @@ runWhenIdle(() => {
 ```
 
 > Note: There are controversial thought on the dynamic scoping and
-> `AsyncContext.Variable`, checkout [SCOPING.md][] for more details.
+> `Variable`, checkout [SCOPING.md][] for more details.
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -185,42 +185,42 @@ only access the value associated with an `AsyncLocal` instance if you have
 access to that instance.
 
 ```typescript
-const asyncLocal = new AsyncLocal();
+const local = new AsyncLocal();
 
 // Sets the current value to 'top', and executes the `main` function.
-asyncLocal.run("top", main);
+local.run("top", main);
 
 function main() {
   // AsyncLocal is maintained through other platform queueing.
   setTimeout(() => {
-    console.log(asyncLocal.get()); // => 'top'
+    console.log(local.get()); // => 'top'
 
-    asyncLocal.run("A", () => {
-      console.log(asyncLocal.get()); // => 'A'
+    local.run("A", () => {
+      console.log(local.get()); // => 'A'
 
       setTimeout(() => {
-        console.log(asyncLocal.get()); // => 'A'
+        console.log(local.get()); // => 'A'
       }, randomTimeout());
     });
   }, randomTimeout());
 
   // AsyncLocal runs can be nested.
-  asyncLocal.run("B", () => {
-    console.log(asyncLocal.get()); // => 'B'
+  local.run("B", () => {
+    console.log(local.get()); // => 'B'
 
     setTimeout(() => {
-      console.log(asyncLocal.get()); // => 'B'
+      console.log(local.get()); // => 'B'
     }, randomTimeout());
   });
 
   // AsyncLocal was restored after the previous run.
-  console.log(asyncLocal.get()); // => 'top'
+  console.log(local.get()); // => 'top'
 
   // Captures the state of all AsyncLocal's at this moment.
   const snapshotDuringTop = new AsyncSnapshot();
 
-  asyncLocal.run("C", () => {
-    console.log(asyncLocal.get()); // => 'C'
+  local.run("C", () => {
+    console.log(local.get()); // => 'C'
 
     // The snapshotDuringTop will restore all AsyncLocal to their snapshot
     // state and invoke the wrapped function. We pass a function which it will
@@ -228,7 +228,7 @@ function main() {
     snapshotDuringTop.run(() => {
       // Despite being lexically nested inside 'C', the snapshot restored us to
       // to the 'top' state.
-      console.log(asyncLocal.get()); // => 'top'
+      console.log(local.get()); // => 'top'
     });
   });
 }
@@ -312,7 +312,7 @@ tracing span doesn't need to be manually passing around by usercodes.
 ```typescript
 // tracer.js
 
-const asyncLocal = new AsyncLocal();
+const local = new AsyncLocal();
 export function run(cb) {
   // (a)
   const span = {
@@ -320,12 +320,12 @@ export function run(cb) {
     traceId: randomUUID(),
     spanId: randomUUID(),
   };
-  asyncLocal.run(span, cb);
+  local.run(span, cb);
 }
 
 export function end() {
   // (b)
-  const span = asyncLocal.get();
+  const span = local.get();
   span?.endTime = Date.now();
 }
 ```
@@ -367,14 +367,14 @@ scheduled with the same priority.
 
 ```typescript
 const scheduler = {
-  asyncLocal: new AsyncLocal(),
+  local: new AsyncLocal(),
   postTask(task, options) {
     // In practice, the task execution may be deferred.
     // Here we simply run the task immediately.
-    return this.asyncLocal.run({ priority: options.priority }, task);
+    return this.local.run({ priority: options.priority }, task);
   },
   currentTask() {
-    return this.asyncLocal.get() ?? { priority: "default" };
+    return this.local.get() ?? { priority: "default" };
   },
 };
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ namespace AsyncContext {
   class Snapshot {
     constructor();
 
-    restore<R>(fn: (...args: any[]) => R, ...args: any[]): R;
+    run<R>(fn: (...args: any[]) => R, ...args: any[]): R;
   }
 }
 ```
@@ -227,7 +227,7 @@ function main() {
     // The snapshotDuringTop will restore all AsyncContext.Variable to their snapshot
     // state and invoke the wrapped function. We pass a function which it will
     // invoke.
-    snapshotDuringTop.restore(() => {
+    snapshotDuringTop.run(() => {
       // Despite being lexically nested inside 'C', the snapshot restored us to
       // to the 'top' state.
       console.log(asyncVar.get()); // => 'top'
@@ -250,7 +250,7 @@ let queue = [];
 export function enqueueCallback(cb: () => void) {
   // Each callback is stored with the context at which it was enqueued.
   const snapshot = new AsyncContext.Snapshot();
-  queue.push(() => snapshot.restore(cb));
+  queue.push(() => snapshot.run(cb));
 }
 
 runWhenIdle(() => {

--- a/SCOPING.md
+++ b/SCOPING.md
@@ -29,19 +29,19 @@ value inside an `AsyncLocal` without explicit access to the `AsyncLocal` instanc
 itself.
 
 ```typescript
-const asyncLocal = new AsyncLocal();
+const local = new AsyncLocal();
 
-asyncLocal.run(1, f);
-console.log(asyncLocal.get()); // => undefined
+local.run(1, f);
+console.log(local.get()); // => undefined
 
 function g() {
-  console.log(asyncLocal.get()); // => 1
+  console.log(local.get()); // => 1
 }
 
 function f() {
-  // Intentionally named the same "asyncLocal"
-  const asyncLocal = new AsyncLocal();
-  asyncLocal.run(2, g);
+  // Intentionally named the same "local"
+  const local = new AsyncLocal();
+  local.run(2, g);
 }
 ```
 
@@ -50,18 +50,18 @@ ability to change the value of that variable. You must have direct access to it
 in order to affect it.
 
 ```typescript
-const asyncLocal = new AsyncLocal();
+const local = new AsyncLocal();
 
-asyncLocal.run(1, f);
+local.run(1, f);
 
-console.log(asyncLocal.get()); // => undefined;
+console.log(local.get()); // => undefined;
 
 function f() {
-  const asyncLocal = new AsyncLocal();
-  asyncLocal.run(2, g);
+  const local = new AsyncLocal();
+  local.run(2, g);
 
   function g() {
-    console.log(asyncLocal.get()); // => 2;
+    console.log(local.get()); // => 2;
   }
 }
 ```
@@ -119,5 +119,5 @@ that can operate across sync/async execution should be no different.
 There are no differences regarding naming scope of `AsyncLocal` compared to
 regular JavaScript variables. Only code with direct access to `AsyncLocal`
 instances can modify the value, and only for code execution nested inside a new
-`asyncLocal.run()`. Further, the capability to modify a local variable which you
+`local.run()`. Further, the capability to modify a local variable which you
 have direct access to is already possible in sync code execution.

--- a/SCOPING.md
+++ b/SCOPING.md
@@ -1,8 +1,9 @@
-# Scoping of AsyncLocal
+# Scoping of AsyncContext.Variable
 
-The major concerns of `AsyncLocal` advancing to Stage 1 of TC39 proposal
+The major concerns of `AsyncContext.Variable` advancing to Stage 1 of TC39 proposal
 process is that there are potential dynamic scoping of the semantics of
-`AsyncLocal`.  This document is about defining the scoping of `AsyncLocal`.
+`AsyncContext.Variable`.  This document is about defining the scoping of
+`AsyncContext.Variable`.
 
 ### Dynamic Scoping
 
@@ -22,61 +23,61 @@ $ echo $x # does this print 1, or 2?
 1
 ```
 
-However, the naming scope of an `AsyncLocal` is identical to a regular variable
+However, the naming scope of an `AsyncContext.Variable` is identical to a regular variable
 in JavaScript. Since JavaScript variables are lexically scoped, the naming of
-`AsyncLocal` instances are lexically scoped too. It is not possible to access a
-value inside an `AsyncLocal` without explicit access to the `AsyncLocal` instance
+`AsyncContext.Variable` instances are lexically scoped too. It is not possible to access a
+value inside an `AsyncContext.Variable` without explicit access to the `AsyncContext.Variable` instance
 itself.
 
 ```typescript
-const local = new AsyncLocal();
+const asyncVar = new AsyncContext.Variable();
 
-local.run(1, f);
-console.log(local.get()); // => undefined
+asyncVar.run(1, f);
+console.log(asyncVar.get()); // => undefined
 
 function g() {
-  console.log(local.get()); // => 1
+  console.log(asyncVar.get()); // => 1
 }
 
 function f() {
-  // Intentionally named the same "local"
-  const local = new AsyncLocal();
-  local.run(2, g);
+  // Intentionally named the same "asyncVar"
+  const asyncVar = new AsyncContext.Variable();
+  asyncVar.run(2, g);
 }
 ```
 
-Hence, knowing the name of an `AsyncLocal` variable does not give you the
+Hence, knowing the name of an `AsyncContext.Variable` variable does not give you the
 ability to change the value of that variable. You must have direct access to it
 in order to affect it.
 
 ```typescript
-const local = new AsyncLocal();
+const asyncVar = new AsyncContext.Variable();
 
-local.run(1, f);
+asyncVar.run(1, f);
 
-console.log(local.get()); // => undefined;
+console.log(asyncVar.get()); // => undefined;
 
 function f() {
-  const local = new AsyncLocal();
-  local.run(2, g);
+  const asyncVar = new AsyncContext.Variable();
+  asyncVar.run(2, g);
 
   function g() {
-    console.log(local.get()); // => 2;
+    console.log(asyncVar.get()); // => 2;
   }
 }
 ```
 
 ### Dynamic Scoping: dependency on caller
 
-One argument on the dynamic scoping is that the values in `AsyncLocal` can be
+One argument on the dynamic scoping is that the values in `AsyncContext.Variable` can be
 changed depending on which the caller is.
 
-However, the definition of whether the value of an `AsyncLocal` can be changed
+However, the definition of whether the value of an `AsyncContext.Variable` can be changed
 has the same meaning with a regular JavaScript variable: anyone with direct
 access to a variable has the ability to change the variable.
 
 ```typescript
-class SyncLocal {
+class SyncVariable {
   #current;
 
   get() {
@@ -94,30 +95,30 @@ class SyncLocal {
   }
 }
 
-const syncLocal = new SyncLocal();
+const syncVar = new SyncVariable();
 
-syncLocal.run(1, f);
+syncVar.run(1, f);
 
-console.log(syncLocal.get()); // => undefined;
+console.log(syncVar.get()); // => undefined;
 
 function g() {
-  console.log(syncLocal.get()); // => 1
+  console.log(syncVar.get()); // => 1
 }
 
 function f() {
-  // Intentionally named the same "syncLocal"
-  const syncLocal = new AsyncLocal();
-  syncLocal.run(2, g);
+  // Intentionally named the same "syncVar"
+  const syncVar = new AsyncContext.Variable();
+  syncVar.run(2, g);
 }
 ```
 
-If this userland `SyncLocal` is acceptable, than adding an `AsyncLocal`
+If this userland `SyncVariable` is acceptable, than adding an `AsyncContext.Variable`
 that can operate across sync/async execution should be no different.
 
 ### Summary
 
-There are no differences regarding naming scope of `AsyncLocal` compared to
-regular JavaScript variables. Only code with direct access to `AsyncLocal`
+There are no differences regarding naming scope of `AsyncContext.Variable` compared to
+regular JavaScript variables. Only code with direct access to `AsyncContext.Variable`
 instances can modify the value, and only for code execution nested inside a new
-`local.run()`. Further, the capability to modify a local variable which you
+`asyncVar.run()`. Further, the capability to modify an AsyncVariable which you
 have direct access to is already possible in sync code execution.

--- a/SCOPING.md
+++ b/SCOPING.md
@@ -1,8 +1,8 @@
-# Scoping of AsyncContext
+# Scoping of AsyncLocal
 
-The major concerns of `AsyncContext` advancing to Stage 1 of TC39 proposal
+The major concerns of `AsyncLocal` advancing to Stage 1 of TC39 proposal
 process is that there are potential dynamic scoping of the semantics of
-`AsyncContext`.  This document is about defining the scoping of `AsyncContext`.
+`AsyncLocal`.  This document is about defining the scoping of `AsyncLocal`.
 
 ### Dynamic Scoping
 
@@ -22,61 +22,61 @@ $ echo $x # does this print 1, or 2?
 1
 ```
 
-However, the naming scope of an async context is identical to a regular variable
+However, the naming scope of an `AsyncLocal` is identical to a regular variable
 in JavaScript. Since JavaScript variables are lexically scoped, the naming of
-async context instances are lexically scoped too. It is not possible to access a
-value inside an async context without explicit access to the async context
+`AsyncLocal` instances are lexically scoped too. It is not possible to access a
+value inside an `AsyncLocal` without explicit access to the `AsyncLocal` instance
 itself.
 
 ```typescript
-const context = new AsyncContext();
+const asyncLocal = new AsyncLocal();
 
-context.run(1, f);
-console.log(context.get()); // => undefined
+asyncLocal.run(1, f);
+console.log(asyncLocal.get()); // => undefined
 
 function g() {
-  console.log(context.get()); // => 1
+  console.log(asyncLocal.get()); // => 1
 }
 
 function f() {
-  // Intentionally named the same "context"
-  const context = new AsyncContext();
-  context.run(2, g);
+  // Intentionally named the same "asyncLocal"
+  const asyncLocal = new AsyncLocal();
+  asyncLocal.run(2, g);
 }
 ```
 
-Hence, knowing the name of an async context variable does not give you the
-ability to change that context. You must have direct access to it in order to
-affect it.
+Hence, knowing the name of an `AsyncLocal` variable does not give you the
+ability to change the value of that variable. You must have direct access to it
+in order to affect it.
 
 ```typescript
-const context = new AsyncContext();
+const asyncLocal = new AsyncLocal();
 
-context.run(1, f);
+asyncLocal.run(1, f);
 
-console.log(context.get()); // => undefined;
+console.log(asyncLocal.get()); // => undefined;
 
 function f() {
-  const context = new AsyncContext();
-  context.run(2, g);
+  const asyncLocal = new AsyncLocal();
+  asyncLocal.run(2, g);
 
   function g() {
-    console.log(context.get(); // => 2;
+    console.log(asyncLocal.get()); // => 2;
   }
 }
 ```
 
 ### Dynamic Scoping: dependency on caller
 
-One argument on the dynamic scoping is that the values in `AsyncContext` can be
+One argument on the dynamic scoping is that the values in `AsyncLocal` can be
 changed depending on which the caller is.
 
-However, the definition of whether the value of an async context can be changed
+However, the definition of whether the value of an `AsyncLocal` can be changed
 has the same meaning with a regular JavaScript variable: anyone with direct
 access to a variable has the ability to change the variable.
 
 ```typescript
-class SyncContext {
+class SyncLocal {
   #current;
 
   get() {
@@ -94,30 +94,30 @@ class SyncContext {
   }
 }
 
-const context = new SyncContext();
+const syncLocal = new SyncLocal();
 
-context.run(1, f);
+syncLocal.run(1, f);
 
-console.log(context.get()); // => undefined;
+console.log(syncLocal.get()); // => undefined;
 
 function g() {
-  console.log(context.get()); // => 1
+  console.log(syncLocal.get()); // => 1
 }
 
 function f() {
-  // Intentionally named the same "context"
-  const context = new AsyncContext();
-  context.run(2, g);
+  // Intentionally named the same "syncLocal"
+  const syncLocal = new AsyncLocal();
+  syncLocal.run(2, g);
 }
 ```
 
-If this userland `SyncContext` is acceptable, than adding an `AsyncContext`
+If this userland `SyncLocal` is acceptable, than adding an `AsyncLocal`
 that can operate across sync/async execution should be no different.
 
 ### Summary
 
-There are no differences regarding naming scope of async contexts compared to
-regular JavaScript variables. Only code with direct access to `AsyncContex`
+There are no differences regarding naming scope of `AsyncLocal` compared to
+regular JavaScript variables. Only code with direct access to `AsyncLocal`
 instances can modify the value, and only for code execution nested inside a new
-`context.run()`. Further, the capability to modify a local variable which you
+`asyncLocal.run()`. Further, the capability to modify a local variable which you
 have direct access to is already possible in sync code execution.

--- a/spec.html
+++ b/spec.html
@@ -16,8 +16,8 @@ contributors: Chengzhong Wu, Justin Ridgewell
     <ins class="block">
     <emu-clause id="sec-asynccontext-mapping-record-specification-type">
       <h1>The Async Context Mapping Record Specification Type</h1>
-      <p>The <dfn variants="Async Context Mapping Records">Async Context Mapping Record</dfn> type is used to represent an AsyncLocal value mapping in the surrounding Agent's [[AsyncContextMapping]].</p>
-      <p>A Async Context Mapping Record's fields are defined by <emu-xref href="#table-asynccontext-mapping-record-fields"></emu-xref>.</p>
+      <p>The <dfn variants="Async Context Mapping Records">Async Context Mapping Record</dfn> type is used to represent an AsyncContext.Variable value mapping in the surrounding Agent's [[AsyncContextMapping]].</p>
+      <p>An Async Context Mapping Record's fields are defined by <emu-xref href="#table-asynccontext-mapping-record-fields"></emu-xref>.</p>
 
       <emu-table id="table-asynccontext-mapping-record-fields" caption="Async Context Mapping Record Fields">
         <table>
@@ -37,10 +37,10 @@ contributors: Chengzhong Wu, Justin Ridgewell
               [[AsyncContextKey]]
             </td>
             <td>
-              an AsyncLocal instance
+              an AsyncContext.Variable instance
             </td>
             <td>
-              The AsyncLocal instance as the key in the mapping.
+              The AsyncContext.Variable instance as the key in the mapping.
             </td>
           </tr>
           <tr>
@@ -51,7 +51,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
               an ECMAScript language value
             </td>
             <td>
-              The value of the AsyncLocal instance in the mapping.
+              The value of the AsyncContext.Variable instance in the mapping.
             </td>
           </tr>
         </table>
@@ -122,7 +122,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
             <ins>a List of Async Context Mapping Records</ins>
           </td>
           <td>
-            <ins>A map from the AsyncLocal instances to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]]. The map is initially empty.</ins>
+            <ins>A map from the AsyncContext.Variable instances to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]]. The map is initially empty.</ins>
           </td>
         </tr>
       </table>
@@ -167,7 +167,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
               <ins>a List of Async Context Mapping Records</ins>
             </td>
             <td>
-              <ins>A map from the AsyncLocal instances to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]].</ins>
+              <ins>A map from the AsyncContext.Variable instances to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]].</ins>
             </td>
           </tr>
           <tr>
@@ -246,12 +246,23 @@ contributors: Chengzhong Wu, Justin Ridgewell
 <emu-clause id="sec-control-abstraction-objects">
   <h1>Control Abstraction Objects</h1>
   <ins class="block">
-  <emu-clause id="sec-asyncsnapshot-objects">
-    <h1>AsyncSnapshot Objects</h1>
 
-    <emu-clause id="sec-asyncsnapshot-abstract-operations">
-      <h1>AsyncSnapshot Abstract Operations</h1>
-      <emu-clause id="sec-asynccontext-snapshot" type="abstract operation">
+  <emu-clause id="sec-asynccontext-object">
+    <h1>The AsyncContext Object</h1>
+    <p>The AsyncContext object:</p>
+    <ul>
+      <li>is the intrinsic object <dfn>%AsyncContext%</dfn>.</li>
+      <li>is the initial value of the *"AsyncContext"* property of the global object.</li>
+      <li>is an ordinary object.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+      <li>is not a function object.</li>
+      <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.</li>
+      <li>does not have a [[Call]] internal method; it cannot be invoked as a function.</li>
+    </ul>
+
+    <emu-clause id="sec-asynccontext-abstract-operations">
+      <h1>AsyncContext Abstract Operations</h1>
+      <emu-clause id="sec-asynccontextsnapshot" type="abstract operation">
         <h1>
           AsyncContextSnapshot (
           ): a List of Async Context Mapping Records
@@ -266,7 +277,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynccontext-swap" type="abstract operation">
+      <emu-clause id="sec-asynccontextswap" type="abstract operation">
         <h1>
           AsyncContextSwap (
             _snapshotMapping_: a List of Async Context Mapping Records
@@ -285,50 +296,66 @@ contributors: Chengzhong Wu, Justin Ridgewell
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-asyncsnapshot-constructor">
-      <h1>The AsyncSnapshot Constructor</h1>
-      <p>The AsyncSnapshot constructor:</p>
+    <emu-clause id="sec-properties-of-the-asynccontext-object">
+      <h1>Constructor Properties of the AsyncContext Object</h1>
+
+      <emu-clause id="sec-asynccontext.snapshot">
+        <h1>AsyncContext.Snapshot ( . . . )</h1>
+        <p>See <emu-xref href="#sec-asynccontext-snapshot-objects"></emu-xref>.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-asynccontext.variable">
+        <h1>AsyncContext.Variable ( . . . )</h1>
+        <p>See <emu-xref href="#sec-asynccontext-variable-objects"></emu-xref>.</p>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-asynccontext-snapshot-objects">
+    <h1>AsyncContext.Snapshot Objects</h1>
+
+    <emu-clause id="sec-asynccontext-snapshot-constructor">
+      <h1>The AsyncContext.Snapshot Constructor</h1>
+      <p>The AsyncContext.Snapshot constructor:</p>
       <ul>
-        <li>is <dfn>%AsyncSnapshot%</dfn>.</li>
-        <li>is the initial value of the *"AsyncSnapshot"* property of the global object.</li>
-        <li>creates and initializes a new AsyncSnapshot when called as a constructor.</li>
+        <li>is <dfn>%AsyncContext.Snapshot%</dfn>.</li>
+        <li>is the initial value of the *"AsyncContext.Snapshot"* property of the %AsyncContext% object.</li>
+        <li>creates and initializes a new AsyncContext.Snapshot when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncSnapshot behaviour must include a `super` call to the AsyncSnapshot constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncSnapshot` and `AsyncSnapshot.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncContext.Snapshot behaviour must include a `super` call to the AsyncContext.Snapshot constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncContext.Snapshot` and `AsyncContext.Snapshot.prototype` built-in methods.</li>
       </ul>
 
-      <emu-clause id="sec-asyncsnapshot">
-        <h1>AsyncSnapshot ( )</h1>
+      <emu-clause id="sec-asynccontext-snapshot">
+        <h1>AsyncContext.Snapshot ( )</h1>
         <p>This function performs the following steps when called:</p>
 
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
           1. Let _snapshotMapping_ be AsyncContextSnapshot().
-          1. Let _asyncSnapshot_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncSnapshot.prototype%"*, « [[AsyncSnapshotMapping]] »).
+          1. Let _asyncSnapshot_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncContext.Snapshot.prototype%"*, « [[AsyncSnapshotMapping]] »).
           1. Set _asyncSnapshot_.[[AsyncSnapshotMapping]] to _snapshotMapping_.
           1. Return _asyncSnapshot_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-properties-of-the-asyncsnapshot-prototype-object">
-      <h1>Properties of the AsyncSnapshot Prototype Object</h1>
-      <p>The <dfn>AsyncSnapshot prototype object</dfn>:</p>
+    <emu-clause id="sec-properties-of-the-asynccontext-snapshot-prototype-object">
+      <h1>Properties of the AsyncContext.Snapshot Prototype Object</h1>
+      <p>The <dfn>AsyncContext.Snapshot prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%AsyncSnapshot.prototype%</dfn>.</li>
+        <li>is <dfn>%AsyncContext.Snapshot.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
-        <li>does not have any of the other internal slots of AsyncSnapshot instances.</li>
+        <li>does not have any of the other internal slots of AsyncContext.Snapshot instances.</li>
       </ul>
 
-      <emu-clause id="sec-asyncsnapshot.prototype.restore">
-        <h1>AsyncSnapshot.prototype.restore ( _func_, ..._args_ )</h1>
+      <emu-clause id="sec-asynccontext-snapshot.prototype.restore">
+        <h1>AsyncContext.Snapshot.prototype.restore ( _func_, ..._args_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _asyncSnapshot_ be the *this* value.
           1. Perform ? RequireInternalSlot(_asyncSnapshot_, [[AsyncSnapshotMapping]]).
-          1. Let _snapshotMapping_ be _asyncSnapshot_.[[AsyncSnapshotMapping]].
-          1. Let _previousContextMapping_ be AsyncContextSnapshot().
-          1. AsyncContextSwap(_snapshotMapping_).
+          1. Let _previousContextMapping_ be AsyncContextSwap(_asyncSnapshot_.[[AsyncSnapshotMapping]]).
           1. Let _result_ be Completion(Call(_func_, *undefined*, _args_)).
           1. AsyncContextSwap(_previousContextMapping_).
           1. Return _result_.
@@ -336,11 +363,11 @@ contributors: Chengzhong Wu, Justin Ridgewell
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-properties-of-asyncsnapshot-instances">
-      <h1>Properties of AsyncSnapshot Instances</h1>
-      <p>AsyncSnapshot instances are ordinary objects that inherit properties from the AsyncSnapshot prototype object (the intrinsic, %AsyncSnapshot.prototype%). AsyncSnapshot instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-asyncsnapshot-instances"></emu-xref>.</p>
+    <emu-clause id="sec-properties-of-asynccontext-snapshot-instances">
+      <h1>Properties of AsyncContext.Snapshot Instances</h1>
+      <p>AsyncContext.Snapshot instances are ordinary objects that inherit properties from the AsyncContext.Snapshot prototype object (the intrinsic, %AsyncContext.Snapshot.prototype%). AsyncContext.Snapshot instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-asynccontext-snapshot-instances"></emu-xref>.</p>
 
-      <emu-table id="table-internal-slots-of-asyncsnapshot-instances" caption="Internal Slots of AsyncSnapshot Instances">
+      <emu-table id="table-internal-slots-of-asynccontext-snapshot-instances" caption="Internal Slots of AsyncContext-Snapshot Instances">
         <table>
           <tr>
             <th>
@@ -361,7 +388,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
               a List of Async Context Mapping Records
             </td>
             <td>
-              Represents the snapshotted surrounding agent's Agent Record's [[AsyncContextMapping]] of the AsyncSnapshot instance.
+              Represents the snapshotted surrounding agent's Agent Record's [[AsyncContextMapping]] of the AsyncContext.Snapshot instance.
             </td>
           </tr>
         </table>
@@ -369,22 +396,22 @@ contributors: Chengzhong Wu, Justin Ridgewell
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-asynclocal-objects">
-    <h1>AsyncLocal Objects</h1>
+  <emu-clause id="sec-asynccontext-variable-objects">
+    <h1>AsyncContext.Variable Objects</h1>
 
-    <emu-clause id="sec-asynclocal-constructor">
-      <h1>The AsyncLocal Constructor</h1>
-      <p>The AsyncLocal constructor:</p>
+    <emu-clause id="sec-asynccontext-variable-constructor">
+      <h1>The AsyncContext.Variable Constructor</h1>
+      <p>The AsyncContext.Variable constructor:</p>
       <ul>
-        <li>is <dfn>%AsyncLocal%</dfn>.</li>
-        <li>is the initial value of the *"AsyncLocal"* property of the global object.</li>
-        <li>creates and initializes a new AsyncLocal when called as a constructor.</li>
+        <li>is <dfn>%AsyncContext.Variable%</dfn>.</li>
+        <li>is the initial value of the *"AsyncContext.Variable"* property of the %AsyncContext% object.</li>
+        <li>creates and initializes a new AsyncContext.Variable when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncLocal behaviour must include a `super` call to the AsyncLocal constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncLocal.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncContext.Variable behaviour must include a `super` call to the AsyncContext.Variable constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncContext.Variable.prototype` built-in methods.</li>
       </ul>
 
-      <emu-clause id="sec-asynclocal">
-        <h1>AsyncLocal ( _options_ )</h1>
+      <emu-clause id="sec-asynccontext-variable">
+        <h1>AsyncContext.Variable ( _options_ )</h1>
         <p>This function performs the following steps when called:</p>
 
         <emu-alg>
@@ -395,40 +422,40 @@ contributors: Chengzhong Wu, Justin Ridgewell
             1. Let _namePresent_ be ? HasProperty(_options_, *"name"*).
             1. If _namePresent_ is *true*, then
               1. Let _name_ be ? Get(_options_, *"name"*).
-              1. Let _nameStr_ be ? ToString(_name_).
-            1. Let _defaultValue_ be ? Get(_options_, *"defaultValue"*).
-          1. Let _asyncLocal_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncLocal.prototype%"*, « [[AsyncLocalName]], [[AsyncLocalDefaultValue]] »).
-          1. Set _asyncLocal_.[[AsyncLocalName]] to _nameStr_.
-          1. Set _asyncLocal_.[[AsyncLocalDefaultValue]] to _defaultValue_.
-          1. Return _asyncLocal_.
+              1. Set _nameStr_ to ? ToString(_name_).
+            1. SEt _defaultValue_ to ? Get(_options_, *"defaultValue"*).
+          1. Let _asyncVariable_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncContext.Variable.prototype%"*, « [[AsyncVariableName]], [[AsyncVariableDefaultValue]] »).
+          1. Set _asyncVariable_.[[AsyncVariableName]] to _nameStr_.
+          1. Set _asyncVariable_.[[AsyncVariableDefaultValue]] to _defaultValue_.
+          1. Return _asyncVariable_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-properties-of-the-asynclocal-prototype-object">
-      <h1>Properties of the AsyncLocal Prototype Object</h1>
-      <p>The <dfn>AsyncLocal prototype object</dfn>:</p>
+    <emu-clause id="sec-properties-of-the-asynccontext-variable-prototype-object">
+      <h1>Properties of the AsyncContext.Variable Prototype Object</h1>
+      <p>The <dfn>AsyncContext.Variable prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%AsyncLocal.prototype%</dfn>.</li>
+        <li>is <dfn>%AsyncContext.Variable.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
-        <li>does not have any of the other internal slots of AsyncLocal instances.</li>
+        <li>does not have any of the other internal slots of AsyncContext.Variable instances.</li>
       </ul>
 
-      <emu-clause id="sec-asynclocal.prototype.run">
-        <h1>AsyncLocal.prototype.run ( _value_, _func_, ..._args_ )</h1>
+      <emu-clause id="sec-asynccontext-variable.prototype.run">
+        <h1>AsyncContext.Variable.prototype.run ( _value_, _func_, ..._args_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _asyncLocal_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalName]]).
+          1. Let _asyncVariable_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_asyncVariable_, [[AsyncVariableName]]).
           1. Let _previousContextMapping_ be AsyncContextSnapshot().
           1. Let _asyncContextMapping_ be a new empty List.
           1. For each Async Context Mapping Record _p_ of _previousContextMapping_, do
-            1. If SameValueZero(_p_.[[AsyncContextKey]], _asyncLocal_) is *false*, then
+            1. If SameValueZero(_p_.[[AsyncContextKey]], _asyncVariable_) is *false*, then
               1. Let _q_ be the Async Context Mapping Record { [[AsyncContextKey]]: _p_.[[AsyncContextKey]], [[AsyncContextValue]]: _p_.[[AsyncContextValue]] }.
               1. Append _q_ to _asyncContextMapping_.
-          1. Assert: _asyncContextMapping_ does not contain an Async Context Mapping Record whose [[AsyncContextKey]] is _asyncLocal_.
-          1. Let _p_ be the Async Context Mapping Record { [[AsyncContextKey]]: _asyncLocal_, [[AsyncContextValue]]: _value_ }.
+          1. Assert: _asyncContextMapping_ does not contain an Async Context Mapping Record whose [[AsyncContextKey]] is _asyncVariable_.
+          1. Let _p_ be the Async Context Mapping Record { [[AsyncContextKey]]: _asyncVariable_, [[AsyncContextValue]]: _value_ }.
           1. Append _p_ to _asyncContextMapping_.
           1. AsyncContextSwap(_asyncContextMapping_).
           1. Let _result_ be Completion(Call(_func_, *undefined*, _args_)).
@@ -437,36 +464,36 @@ contributors: Chengzhong Wu, Justin Ridgewell
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynclocal.prototype.name">
-        <h1>get AsyncLocal.prototype.name</h1>
-        <p>`AsyncLocal.prototype.name` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+      <emu-clause id="sec-asynccontext-variable.prototype.name">
+        <h1>get AsyncContext.Variable.prototype.name</h1>
+        <p>`AsyncContext.Variable.prototype.name` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
-          1. Let _asyncLocal_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalName]]).
-          1. Return _asyncLocal_.[[AsyncLocalName]].
+          1. Let _asyncVariable_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_asyncVariable_, [[AsyncVariableName]]).
+          1. Return _asyncVariable_.[[AsyncVariableName]].
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-asynclocal.prototype.get">
-        <h1>AsyncLocal.prototype.get ( )</h1>
+      <emu-clause id="sec-asynccontext-variable.prototype.get">
+        <h1>AsyncContext.Variable.prototype.get ( )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _asyncLocal_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalName]]).
+          1. Let _asyncVariable_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_asyncVariable_, [[AsyncVariableDefaultValue]]).
           1. Let _agentRecord_ be the surrounding agent's Agent Record.
           1. Let _asyncContextMapping_ be _agentRecord_.[[AsyncContextMapping]].
           1. For each Async Context Mapping Record _p_ of _asyncContextMapping_, do
-            1. If SameValueZero(_p_.[[AsyncContextKey]], _asyncLocal_) is *true*, return _p_.[[AsyncContextValue]].
-          1. Return _asyncLocal_.[[AsyncLocalDefaultValue]].
+            1. If SameValueZero(_p_.[[AsyncContextKey]], _asyncVariable_) is *true*, return _p_.[[AsyncContextValue]].
+          1. Return _asyncVariable_.[[AsyncVariableDefaultValue]].
         </emu-alg>
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-properties-of-asynclocal-instances">
-      <h1>Properties of AsyncLocal Instances</h1>
-      <p>AsyncLocal instances are ordinary objects that inherit properties from the AsyncLocal prototype object (the intrinsic, %AsyncLocal.prototype%). AsyncLocal instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-asynclocal-instances"></emu-xref>.</p>
+    <emu-clause id="sec-properties-of-asynccontext-variable-instances">
+      <h1>Properties of AsyncContext.Variable Instances</h1>
+      <p>AsyncContext.Variable instances are ordinary objects that inherit properties from the AsyncContext.Variable prototype object (the intrinsic, %AsyncContext.Variable.prototype%). AsyncContext.Variable instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-asynccontext-variable-instances"></emu-xref>.</p>
 
-      <emu-table id="table-internal-slots-of-asynclocal-instances" caption="Internal Slots of AsyncLocal Instances">
+      <emu-table id="table-internal-slots-of-asynccontext-variable-instances" caption="Internal Slots of AsyncContext.Variable Instances">
         <table>
           <tr>
             <th>
@@ -481,24 +508,24 @@ contributors: Chengzhong Wu, Justin Ridgewell
           </tr>
           <tr>
             <td>
-              [[AsyncLocalName]]
+              [[AsyncVariableName]]
             </td>
             <td>
               a String
             </td>
             <td>
-              The name of the AsyncLocal instance.
+              The name of the AsyncContext.Variable instance.
             </td>
           </tr>
           <tr>
             <td>
-              [[AsyncLocalDefaultValue]]
+              [[AsyncVariableDefaultValue]]
             </td>
             <td>
               an ECMAScript language value
             </td>
             <td>
-              The default value of the AsyncLocal instance when no entry is found in the mapping.
+              The default value of the AsyncContext.Variable instance when no entry is found in the mapping.
             </td>
           </tr>
         </table>

--- a/spec.html
+++ b/spec.html
@@ -319,7 +319,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
       <p>The AsyncContext.Snapshot constructor:</p>
       <ul>
         <li>is <dfn>%AsyncContext.Snapshot%</dfn>.</li>
-        <li>is the initial value of the *"AsyncContext.Snapshot"* property of the %AsyncContext% object.</li>
+        <li>is the initial value of the *"Snapshot"* property of the %AsyncContext% object.</li>
         <li>creates and initializes a new AsyncContext.Snapshot when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncContext.Snapshot behaviour must include a `super` call to the AsyncContext.Snapshot constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncContext.Snapshot` and `AsyncContext.Snapshot.prototype` built-in methods.</li>
@@ -404,7 +404,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
       <p>The AsyncContext.Variable constructor:</p>
       <ul>
         <li>is <dfn>%AsyncContext.Variable%</dfn>.</li>
-        <li>is the initial value of the *"AsyncContext.Variable"* property of the %AsyncContext% object.</li>
+        <li>is the initial value of the *"Variable"* property of the %AsyncContext% object.</li>
         <li>creates and initializes a new AsyncContext.Variable when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
         <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncContext.Variable behaviour must include a `super` call to the AsyncContext.Variable constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncContext.Variable.prototype` built-in methods.</li>

--- a/spec.html
+++ b/spec.html
@@ -40,7 +40,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
               an AsyncLocal instance
             </td>
             <td>
-              The name of the AsyncLocal instance.
+              The AsyncLocal instance as the key in the mapping.
             </td>
           </tr>
           <tr>
@@ -51,7 +51,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
               an ECMAScript language value
             </td>
             <td>
-              The default value of the AsyncLocal instance when no entry is found in the mapping.
+              The value of the AsyncLocal instance in the mapping.
             </td>
           </tr>
         </table>
@@ -122,7 +122,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
             <ins>a List of Async Context Mapping Records</ins>
           </td>
           <td>
-            <ins>A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]].</ins>
+            <ins>A map from the AsyncLocal instances to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]]. The map is initially empty.</ins>
           </td>
         </tr>
       </table>
@@ -167,7 +167,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
               <ins>a List of Async Context Mapping Records</ins>
             </td>
             <td>
-              <ins>A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]].</ins>
+              <ins>A map from the AsyncLocal instances to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]].</ins>
             </td>
           </tr>
           <tr>
@@ -320,8 +320,8 @@ contributors: Chengzhong Wu, Justin Ridgewell
         <li>does not have any of the other internal slots of AsyncSnapshot instances.</li>
       </ul>
 
-      <emu-clause id="sec-asyncsnapshot.prototype.run">
-        <h1>AsyncSnapshot.prototype.run ( _func_, ..._args_ )</h1>
+      <emu-clause id="sec-asyncsnapshot.prototype.restore">
+        <h1>AsyncSnapshot.prototype.restore ( _func_, ..._args_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _asyncSnapshot_ be the *this* value.
@@ -380,7 +380,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
         <li>is the initial value of the *"AsyncLocal"* property of the global object.</li>
         <li>creates and initializes a new AsyncLocal when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncLocal behaviour must include a `super` call to the AsyncLocal constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncLocal` and `AsyncLocal.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncLocal behaviour must include a `super` call to the AsyncLocal constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncLocal.prototype` built-in methods.</li>
       </ul>
 
       <emu-clause id="sec-asynclocal">
@@ -389,13 +389,14 @@ contributors: Chengzhong Wu, Justin Ridgewell
 
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
+          1. Let _nameStr_ be the empty String.
+          1. Let _defaultValue_ be *undefined*.
           1. If _options_ is an Object, then
-            1. Let _name_ be ? Get(_options_, *"name"*).
-            1. Let _nameStr_ be ? ToString(_name_).
+            1. Let _namePresent_ be ? HasProperty(_options_, *"name"*).
+            1. If _namePresent_ is *true*, then
+              1. Let _name_ be ? Get(_options_, *"name"*).
+              1. Let _nameStr_ be ? ToString(_name_).
             1. Let _defaultValue_ be ? Get(_options_, *"defaultValue"*).
-          1. Else,
-            1. Let _nameStr_ be the empty String.
-            1. Let _defaultValue_ be *undefined*.
           1. Let _asyncLocal_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncLocal.prototype%"*, « [[AsyncLocalName]], [[AsyncLocalDefaultValue]] »).
           1. Set _asyncLocal_.[[AsyncLocalName]] to _nameStr_.
           1. Set _asyncLocal_.[[AsyncLocalDefaultValue]] to _defaultValue_.

--- a/spec.html
+++ b/spec.html
@@ -349,8 +349,8 @@ contributors: Chengzhong Wu, Justin Ridgewell
         <li>does not have any of the other internal slots of AsyncContext.Snapshot instances.</li>
       </ul>
 
-      <emu-clause id="sec-asynccontext-snapshot.prototype.restore">
-        <h1>AsyncContext.Snapshot.prototype.restore ( _func_, ..._args_ )</h1>
+      <emu-clause id="sec-asynccontext-snapshot.prototype.run">
+        <h1>AsyncContext.Snapshot.prototype.run ( _func_, ..._args_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _asyncSnapshot_ be the *this* value.

--- a/spec.html
+++ b/spec.html
@@ -423,7 +423,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
             1. If _namePresent_ is *true*, then
               1. Let _name_ be ? Get(_options_, *"name"*).
               1. Set _nameStr_ to ? ToString(_name_).
-            1. SEt _defaultValue_ to ? Get(_options_, *"defaultValue"*).
+            1. Set _defaultValue_ to ? Get(_options_, *"defaultValue"*).
           1. Let _asyncVariable_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncContext.Variable.prototype%"*, « [[AsyncVariableName]], [[AsyncVariableDefaultValue]] »).
           1. Set _asyncVariable_.[[AsyncVariableName]] to _nameStr_.
           1. Set _asyncVariable_.[[AsyncVariableDefaultValue]] to _defaultValue_.

--- a/spec.html
+++ b/spec.html
@@ -7,6 +7,60 @@ stage: 1
 contributors: Chengzhong Wu, Justin Ridgewell
 </pre>
 
+<emu-clause id="sec-ecmascript-data-types-and-values">
+  <h1>ECMAScript Data Types and Values</h1>
+
+  <emu-clause id="sec-ecmascript-specification-types">
+    <h1>ECMAScript Specification Types</h1>
+
+    <ins class="block">
+    <emu-clause id="sec-asynccontext-mapping-record-specification-type">
+      <h1>The Async Context Mapping Record Specification Type</h1>
+      <p>The <dfn variants="Async Context Mapping Records">Async Context Mapping Record</dfn> type is used to represent an AsyncLocal value mapping in the surrounding Agent's [[AsyncContextMapping]].</p>
+      <p>A Async Context Mapping Record's fields are defined by <emu-xref href="#table-asynccontext-mapping-record-fields"></emu-xref>.</p>
+
+      <emu-table id="table-asynccontext-mapping-record-fields" caption="Async Context Mapping Record Fields">
+        <table>
+          <tr>
+            <th>
+              Field Name
+            </th>
+            <th>
+              Value
+            </th>
+            <th>
+              Meaning
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[AsyncContextKey]]
+            </td>
+            <td>
+              an AsyncLocal instance
+            </td>
+            <td>
+              The name of the AsyncLocal instance.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[AsyncContextValue]]
+            </td>
+            <td>
+              an ECMAScript language value
+            </td>
+            <td>
+              The default value of the AsyncLocal instance when no entry is found in the mapping.
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+    </ins>
+  </emu-clause>
+</emu-clause>
+
 <emu-clause id="sec-executable-code-and-execution-contexts">
   <h1>Executable Code and Execution Contexts</h1>
 
@@ -65,10 +119,10 @@ contributors: Chengzhong Wu, Justin Ridgewell
             <ins>[[AsyncContextMapping]]</ins>
           </td>
           <td>
-            <ins>a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)</ins>
+            <ins>a List of Async Context Mapping Records</ins>
           </td>
           <td>
-            <ins>A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncLocalKey]].</ins>
+            <ins>A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]].</ins>
           </td>
         </tr>
       </table>
@@ -110,10 +164,10 @@ contributors: Chengzhong Wu, Justin Ridgewell
               <ins>[[AsyncContextSnapshot]]</ins>
             </td>
             <td>
-              <ins>a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)</ins>
+              <ins>a List of Async Context Mapping Records</ins>
             </td>
             <td>
-              <ins>A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncLocalKey]].</ins>
+              <ins>A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]].</ins>
             </td>
           </tr>
           <tr>
@@ -147,8 +201,8 @@ contributors: Chengzhong Wu, Justin Ridgewell
       <p>The default implementation of HostMakeJobCallback performs the following steps when called:</p>
       <emu-alg>
         1. <del>Return the JobCallback Record { [[Callback]]: _callback_, [[HostDefined]]: ~empty~ }.</del>
-        1. <ins>Let _snapshot_ be AsyncContextSnapshot().</ins>
-        1. <ins>Return the JobCallback Record { [[Callback]]: _callback_, [[AsyncContextSnapshot]]: _snapshot_, [[HostDefined]]: ~empty~ }.</ins>
+        1. <ins>Let _snapshotMapping_ be AsyncContextSnapshot().</ins>
+        1. <ins>Return the JobCallback Record { [[Callback]]: _callback_, [[AsyncContextSnapshot]]: _snapshotMapping_, [[HostDefined]]: ~empty~ }.</ins>
       </emu-alg>
       <p>ECMAScript hosts that are not web browsers must use the default implementation of HostMakeJobCallback.</p>
       <emu-note>
@@ -189,9 +243,9 @@ contributors: Chengzhong Wu, Justin Ridgewell
   </emu-clause>
 </emu-clause>
 
-<ins class="block">
 <emu-clause id="sec-control-abstraction-objects">
   <h1>Control Abstraction Objects</h1>
+  <ins class="block">
   <emu-clause id="sec-asyncsnapshot-objects">
     <h1>AsyncSnapshot Objects</h1>
 
@@ -200,7 +254,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
       <emu-clause id="sec-asynccontext-snapshot" type="abstract operation">
         <h1>
           AsyncContextSnapshot (
-          ): a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)
+          ): a List of Async Context Mapping Records
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -215,17 +269,17 @@ contributors: Chengzhong Wu, Justin Ridgewell
       <emu-clause id="sec-asynccontext-swap" type="abstract operation">
         <h1>
           AsyncContextSwap (
-            _snapshot_: a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)
-          ): a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)
+            _snapshotMapping_: a List of Async Context Mapping Records
+          ): a List of Async Context Mapping Records
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It is used to swap the surrounding agent's Agent Record's [[AsyncContextMapping]] with the _snapshot_.</dd>
+          <dd>It is used to swap the surrounding agent's Agent Record's [[AsyncContextMapping]] with the _snapshotMapping_.</dd>
         </dl>
         <emu-alg>
           1. Let _agentRecord_ be the surrounding agent's Agent Record.
           1. Let _asyncContextMapping_ be _agentRecord_.[[AsyncContextMapping]].
-          1. Set _agentRecord_.[[AsyncContextMapping]] to _snapshot_.
+          1. Set _agentRecord_.[[AsyncContextMapping]] to _snapshotMapping_.
           1. Return _asyncContextMapping_.
         </emu-alg>
       </emu-clause>
@@ -248,9 +302,9 @@ contributors: Chengzhong Wu, Justin Ridgewell
 
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _snapshot_ be AsyncContextSnapshot().
+          1. Let _snapshotMapping_ be AsyncContextSnapshot().
           1. Let _asyncSnapshot_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncSnapshot.prototype%"*, « [[AsyncSnapshotMapping]] »).
-          1. Set _asyncSnapshot_.[[AsyncSnapshotMapping]] to _snapshot_.
+          1. Set _asyncSnapshot_.[[AsyncSnapshotMapping]] to _snapshotMapping_.
           1. Return _asyncSnapshot_.
         </emu-alg>
       </emu-clause>
@@ -272,11 +326,11 @@ contributors: Chengzhong Wu, Justin Ridgewell
         <emu-alg>
           1. Let _asyncSnapshot_ be the *this* value.
           1. Perform ? RequireInternalSlot(_asyncSnapshot_, [[AsyncSnapshotMapping]]).
-          1. Let _snapshot_ be _asyncSnapshot_.[[AsyncSnapshotMapping]].
-          1. Let _contextMapping_ be AsyncContextSnapshot().
-          1. AsyncContextSwap(_snapshot_).
+          1. Let _snapshotMapping_ be _asyncSnapshot_.[[AsyncSnapshotMapping]].
+          1. Let _previousContextMapping_ be AsyncContextSnapshot().
+          1. AsyncContextSwap(_snapshotMapping_).
           1. Let _result_ be Completion(Call(_func_, *undefined*, _args_)).
-          1. AsyncContextSwap(_contextMapping_).
+          1. AsyncContextSwap(_previousContextMapping_).
           1. Return _result_.
         </emu-alg>
       </emu-clause>
@@ -304,7 +358,7 @@ contributors: Chengzhong Wu, Justin Ridgewell
               [[AsyncSnapshotMapping]]
             </td>
             <td>
-              a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)
+              a List of Async Context Mapping Records
             </td>
             <td>
               Represents the snapshotted surrounding agent's Agent Record's [[AsyncContextMapping]] of the AsyncSnapshot instance.
@@ -342,8 +396,8 @@ contributors: Chengzhong Wu, Justin Ridgewell
           1. Else,
             1. Let _nameStr_ be the empty String.
             1. Let _defaultValue_ be *undefined*.
-          1. Let _asyncLocal_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncLocal.prototype%"*, « [[AsyncLocalKey]], [[AsyncLocalDefaultValue]] »).
-          1. Set _asyncLocal_.[[AsyncLocalKey]] to a new Symbol whose [[Description]] is _nameStr_.
+          1. Let _asyncLocal_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncLocal.prototype%"*, « [[AsyncLocalName]], [[AsyncLocalDefaultValue]] »).
+          1. Set _asyncLocal_.[[AsyncLocalName]] to _nameStr_.
           1. Set _asyncLocal_.[[AsyncLocalDefaultValue]] to _defaultValue_.
           1. Return _asyncLocal_.
         </emu-alg>
@@ -365,16 +419,15 @@ contributors: Chengzhong Wu, Justin Ridgewell
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _asyncLocal_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalKey]]).
-          1. Let _AsyncLocalKey_ be _asyncLocal_.[[AsyncLocalKey]].
+          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalName]]).
           1. Let _previousContextMapping_ be AsyncContextSnapshot().
           1. Let _asyncContextMapping_ be a new empty List.
-          1. For each Record { [[AsyncLocalKey]], [[AsyncLocalValue]] } _p_ of _previousContextMapping_, do
-            1. If SameValueZero(_p_.[[AsyncLocalKey]], _AsyncLocalKey_) is *false*, then
-              1. Let _q_ be the Record { [[AsyncLocalKey]]: _p_.[[AsyncLocalKey]], [[AsyncLocalValue]]: _p_.[[AsyncLocalValue]] }.
+          1. For each Async Context Mapping Record _p_ of _previousContextMapping_, do
+            1. If SameValueZero(_p_.[[AsyncContextKey]], _asyncLocal_) is *false*, then
+              1. Let _q_ be the Async Context Mapping Record { [[AsyncContextKey]]: _p_.[[AsyncContextKey]], [[AsyncContextValue]]: _p_.[[AsyncContextValue]] }.
               1. Append _q_ to _asyncContextMapping_.
-          1. Assert: _asyncContextMapping_ does not contain a Record whose [[AsyncLocalKey]] is _AsyncLocalKey_.
-          1. Let _p_ be the Record { [[AsyncLocalKey]]: _AsyncLocalKey_, [[AsyncLocalValue]]: _value_ }.
+          1. Assert: _asyncContextMapping_ does not contain an Async Context Mapping Record whose [[AsyncContextKey]] is _asyncLocal_.
+          1. Let _p_ be the Async Context Mapping Record { [[AsyncContextKey]]: _asyncLocal_, [[AsyncContextValue]]: _value_ }.
           1. Append _p_ to _asyncContextMapping_.
           1. AsyncContextSwap(_asyncContextMapping_).
           1. Let _result_ be Completion(Call(_func_, *undefined*, _args_)).
@@ -388,10 +441,8 @@ contributors: Chengzhong Wu, Justin Ridgewell
         <p>`AsyncLocal.prototype.name` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _asyncLocal_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalKey]]).
-          1. Let _asyncLocalKey_ be _asyncLocal_.[[AsyncLocalKey]].
-          1. Assert: _asyncLocalKey_ is a Symbol.
-          1. Return _asyncLocalKey_.[[Description]].
+          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalName]]).
+          1. Return _asyncLocal_.[[AsyncLocalName]].
         </emu-alg>
       </emu-clause>
 
@@ -400,11 +451,11 @@ contributors: Chengzhong Wu, Justin Ridgewell
         <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _asyncLocal_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalKey]]).
+          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalName]]).
           1. Let _agentRecord_ be the surrounding agent's Agent Record.
           1. Let _asyncContextMapping_ be _agentRecord_.[[AsyncContextMapping]].
-          1. For each Record { [[AsyncLocalKey]], [[AsyncLocalValue]] } _p_ of _asyncContextMapping_, do
-            1. If SameValueZero(_p_.[[AsyncLocalKey]], _asyncLocal_.[[AsyncLocalKey]]) is *true*, return _p_.[[AsyncLocalValue]].
+          1. For each Async Context Mapping Record _p_ of _asyncContextMapping_, do
+            1. If SameValueZero(_p_.[[AsyncContextKey]], _asyncLocal_) is *true*, return _p_.[[AsyncContextValue]].
           1. Return _asyncLocal_.[[AsyncLocalDefaultValue]].
         </emu-alg>
       </emu-clause>
@@ -429,13 +480,13 @@ contributors: Chengzhong Wu, Justin Ridgewell
           </tr>
           <tr>
             <td>
-              [[AsyncLocalKey]]
+              [[AsyncLocalName]]
             </td>
             <td>
-              a Symbol
+              a String
             </td>
             <td>
-              Represents the AsyncLocal instance in the surrounding agent's Agent Record's [[AsyncContextMapping]].
+              The name of the AsyncLocal instance.
             </td>
           </tr>
           <tr>
@@ -453,6 +504,5 @@ contributors: Chengzhong Wu, Justin Ridgewell
       </emu-table>
     </emu-clause>
   </emu-clause>
+  </ins>
 </emu-clause>
-</ins>
-

--- a/spec.html
+++ b/spec.html
@@ -65,10 +65,10 @@ contributors: Chengzhong Wu, Justin Ridgewell
             <ins>[[AsyncContextMapping]]</ins>
           </td>
           <td>
-            <ins>a List of Records with fields [[AsyncContextKey]] (a Symbol) and [[AsyncContextValue]] (an ECMAScript language value)</ins>
+            <ins>a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)</ins>
           </td>
           <td>
-            <ins>A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]].</ins>
+            <ins>A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncLocalKey]].</ins>
           </td>
         </tr>
       </table>
@@ -110,10 +110,10 @@ contributors: Chengzhong Wu, Justin Ridgewell
               <ins>[[AsyncContextSnapshot]]</ins>
             </td>
             <td>
-              <ins>a List of Records with fields [[AsyncContextKey]] (a Symbol) and [[AsyncContextValue]] (an ECMAScript language value)</ins>
+              <ins>a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)</ins>
             </td>
             <td>
-              <ins>A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]].</ins>
+              <ins>A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncLocalKey]].</ins>
             </td>
           </tr>
           <tr>
@@ -190,146 +190,17 @@ contributors: Chengzhong Wu, Justin Ridgewell
 </emu-clause>
 
 <ins class="block">
-<emu-clause id="sec-ordinary-and-exotic-objects-behaviours">
-  <h1>Ordinary and Exotic Objects Behaviours</h1>
-  <emu-clause id="sec-built-in-exotic-object-internal-methods-and-slots">
-    <h1>Built-in Exotic Object Internal Methods and Slots</h1>
-
-    <emu-clause id="sec-asynccontext-wrapped-function-exotic-objects">
-      <h1>AsyncContext Wrapped Function Exotic Objects</h1>
-
-      <emu-note>
-        <p>This is based on <emu-xref href="#sec-bound-function-exotic-objects"></emu-xref></p>
-      </emu-note>
-
-      <p>An AsyncContext wrapped function exotic object is an exotic object that wraps another function object. An AsyncContext wrapped function exotic object is callable (it has a [[Call]] internal method and may have a [[Construct]] internal method). Calling an AsyncContext wrapped function exotic object generally results in a call of its wrapped function.</p>
-
-      <p>An object is a <dfn id="asynccontext-wrapped-function-exotic-object" variants="async context wrapped function exotic objects">AsyncContext wrapped function exotic object</dfn> if its [[Call]] and (if applicable) [[Construct]] internal methods use the following implementations, and its other essential internal methods use the definitions found in Ordinary Object Internal Methods and Internal Slots. These methods are installed in AsyncContextWrappedFunctionCreate.</p>
-
-      <p>Async context wrapped function exotic objects do not have the internal slots of ECMAScript function objects listed in Internal Slots of ECMAScript Function Objects. Instead they have the internal slots listed in <emu-xref href="#table-internal-slots-of-asynccontext-wrapped-function-exotic-objects"></emu-xref>, in addition to [[Prototype]] and [[Extensible]].</p>
-      <emu-table id="table-internal-slots-of-asynccontext-wrapped-function-exotic-objects" caption="Internal Slots of AsyncContext Wrapped Function Exotic Objects">
-        <table>
-          <tr>
-            <th>
-              Internal Slot
-            </th>
-            <th>
-              Type
-            </th>
-            <th>
-              Description
-            </th>
-          </tr>
-          <tr>
-            <td>
-              [[WrappedTargetFunction]]
-            </td>
-            <td>
-              a callable Object
-            </td>
-            <td>
-              The wrapped function object.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              [[AsyncContextSnapshot]]
-            </td>
-            <td>
-              a List of Records with fields [[AsyncContextKey]] (a Symbol) and [[AsyncContextValue]] (an ECMAScript language value)
-            </td>
-            <td>
-              A map from the AsyncContext's key symbol to the saved ECMAScript language value. Every Record in the List contains a unique [[AsyncContextKey]].
-            </td>
-          </tr>
-        </table>
-      </emu-table>
-
-      <emu-clause id="sec-asynccontext-wrapped-function-exotic-objects-call-thisargument-argumentslist" type="internal method">
-        <h1>
-          [[Call]] (
-            _thisArgument_: an ECMAScript language value,
-            _argumentsList_: a List of ECMAScript language values,
-          ): either a normal completion containing an ECMAScript language value or a throw completion
-        </h1>
-        <dl class="header">
-          <dt>for</dt>
-          <dd>an AsyncContext wrapped function exotic object _F_</dd>
-        </dl>
-        <emu-alg>
-          1. Let _target_ be F.[[WrappedTargetFunction]].
-          1. Let _snapshot_ be F.[[AsyncContextSnapshot]].
-          1. Let _previousContextMapping_ be AsyncContextSwap(_snapshot_).
-          1. Let _result_ be Completion(Call(_target_, _thisArgument_, _argumentsList_)).
-          1. AsyncContextSwap(_previousContextMapping_).
-          1. Return _result_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-asynccontext-wrapped-function-exotic-objects-construct-argumentslist-newtarget" type="internal method">
-        <h1>
-          [[Construct]] (
-            _argumentsList_: a List of ECMAScript language values,
-            _newTarget_: a constructor,
-          ): either a normal completion containing an Object or a throw completion
-        </h1>
-        <dl class="header">
-          <dt>for</dt>
-          <dd>an AsyncContext wrapped function exotic object _F_</dd>
-        </dl>
-        <emu-alg>
-          1. Let _target_ be _F_.[[WrappedTargetFunction]].
-          1. Assert: IsConstructor(_target_) is *true*.
-          1. Let _snapshot_ be F.[[AsyncContextSnapshot]].
-          1. Let _previousContextMapping_ be AsyncContextSwap(_snapshot_).
-          1. If SameValue(_F_, _newTarget_) is *true*, set _newTarget_ to _target_.
-          1. Let _result_ be Completion(Construct(_target_, _argumentsList_, _newTarget_)).
-          1. AsyncContextSwap(_previousContextMapping_).
-          1. Return _result_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-asynccontext-wrappedfunctioncreate" type="abstract operation">
-        <h1>
-          AsyncContextWrappedFunctionCreate (
-            _targetFunction_: a function object,
-            _snapshot_: a List of Records with fields [[AsyncContextKey]] (a Symbol) and [[AsyncContextValue]] (an ECMAScript language value),
-          ): either a normal completion containing a function object or a throw completion
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It is used to specify the creation of new AsyncContext wrapped function exotic objects.</dd>
-        </dl>
-        <emu-alg>
-          1. Let _proto_ be ? <emu-meta effects="user-code">_targetFunction_.[[GetPrototypeOf]]</emu-meta>().
-          1. Let _internalSlotsList_ be the list-concatenation of « [[Prototype]], [[Extensible]] » and the internal slots listed in <emu-xref href="#table-internal-slots-of-asynccontext-wrapped-function-exotic-objects"></emu-xref>.
-          1. Let _obj_ be MakeBasicObject(_internalSlotsList_).
-          1. Set _obj_.[[Prototype]] to _proto_.
-          1. Set _obj_.[[Call]] as described in <emu-xref href="#sec-asynccontext-wrapped-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
-          1. If IsConstructor(_targetFunction_) is *true*, then
-            1. Set _obj_.[[Construct]] as described in <emu-xref href="#sec-asynccontext-wrapped-function-exotic-objects-construct-argumentslist-newtarget"></emu-xref>.
-          1. Set _obj_.[[WrappedTargetFunction]] to _targetFunction_.
-          1. Set _obj_.[[AsyncContextSnapshot]] to _snapshot_.
-          1. Return _obj_.
-        </emu-alg>
-      </emu-clause>
-    </emu-clause>
-  </emu-clause>
-</emu-clause>
-</ins>
-
-<ins class="block">
 <emu-clause id="sec-control-abstraction-objects">
   <h1>Control Abstraction Objects</h1>
-  <emu-clause id="sec-asynccontext-objects">
-    <h1>AsyncContext Objects</h1>
+  <emu-clause id="sec-asyncsnapshot-objects">
+    <h1>AsyncSnapshot Objects</h1>
 
-    <emu-clause id="sec-asynccontext-abstract-operations">
-      <h1>AsyncContext Abstract Operations</h1>
+    <emu-clause id="sec-asyncsnapshot-abstract-operations">
+      <h1>AsyncSnapshot Abstract Operations</h1>
       <emu-clause id="sec-asynccontext-snapshot" type="abstract operation">
         <h1>
           AsyncContextSnapshot (
-          ): a List of Records with fields [[AsyncContextKey]] (a Symbol) and [[AsyncContextValue]] (an ECMAScript language value)
+          ): a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -344,8 +215,8 @@ contributors: Chengzhong Wu, Justin Ridgewell
       <emu-clause id="sec-asynccontext-swap" type="abstract operation">
         <h1>
           AsyncContextSwap (
-            _snapshot_: a List of Records with fields [[AsyncContextKey]] (a Symbol) and [[AsyncContextValue]] (an ECMAScript language value)
-          ): a List of Records with fields [[AsyncContextKey]] (a Symbol) and [[AsyncContextValue]] (an ECMAScript language value)
+            _snapshot_: a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)
+          ): a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -360,139 +231,62 @@ contributors: Chengzhong Wu, Justin Ridgewell
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-asynccontext-constructor">
-      <h1>The AsyncContext Constructor</h1>
-      <p>The AsyncContext constructor:</p>
+    <emu-clause id="sec-asyncsnapshot-constructor">
+      <h1>The AsyncSnapshot Constructor</h1>
+      <p>The AsyncSnapshot constructor:</p>
       <ul>
-        <li>is <dfn>%AsyncContext%</dfn>.</li>
-        <li>is the initial value of the *"AsyncContext"* property of the global object.</li>
-        <li>creates and initializes a new AsyncContext when called as a constructor.</li>
+        <li>is <dfn>%AsyncSnapshot%</dfn>.</li>
+        <li>is the initial value of the *"AsyncSnapshot"* property of the global object.</li>
+        <li>creates and initializes a new AsyncSnapshot when called as a constructor.</li>
         <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncContext behaviour must include a `super` call to the AsyncContext constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncContext` and `AsyncContext.prototype` built-in methods.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncSnapshot behaviour must include a `super` call to the AsyncSnapshot constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncSnapshot` and `AsyncSnapshot.prototype` built-in methods.</li>
       </ul>
 
-      <emu-clause id="sec-asynccontext">
-        <h1>AsyncContext ( _options_ )</h1>
+      <emu-clause id="sec-asyncsnapshot">
+        <h1>AsyncSnapshot ( )</h1>
         <p>This function performs the following steps when called:</p>
 
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. If _options_ is an Object, then
-            1. Let _name_ be ? Get(_options_, *"name"*).
-            1. Let _nameStr_ be ? ToString(_name_).
-            1. Let _defaultValue_ be ? Get(_options_, *"defaultValue"*).
-          1. Else,
-            1. Let _nameStr_ be the empty String.
-            1. Let _defaultValue_ be *undefined*.
-          1. Let _asyncContext_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncContext.prototype%"*, « [[AsyncContextKey]] »).
-          1. Set _asyncContext_.[[AsyncContextKey]] to a new Symbol whose [[Description]] is _nameStr_.
-          1. Set _asyncContext_.[[AsyncContextDefaultValue]] to _defaultValue_.
-          1. Return _asyncContext_.
-        </emu-alg>
-      </emu-clause>
-    </emu-clause>
-
-    <emu-clause id="sec-properties-of-the-asynccontext-constructor">
-      <h1>Properties of the AsyncContext Constructor</h1>
-      <p>The AsyncContext constructor:</p>
-      <ul>
-        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
-        <li>has the following properties:</li>
-      </ul>
-
-      <emu-clause id="sec-asynccontext-wrap">
-        <h1>AsyncContext.wrap ( _target_ )</h1>
-        <p>This function returns a new function which opaquely captures the current value of all AsyncContexts and restores the captured value when being invoked.</p>
-
-        <emu-alg>
           1. Let _snapshot_ be AsyncContextSnapshot().
-          1. If IsCallable(_target_) is false, throw a TypeError exception.
-          1. Let _F_ be ? AsyncContextWrappedFunctionCreate(_target_, _snapshot_).
-          1. Let _L_ be 0.
-          1. Let _targetHasLength_ be ? HasOwnProperty(_target_, *"length"*).
-          1. If _targetHasLength_ is *true*, then
-            1. Let _targetLen_ be ? Get(_target_, *"length"*).
-            1. If _targetLen_ is a Number, then
-              1. If _targetLen_ is *+∞*<sub>𝔽</sub>, set _L_ to +∞.
-              1. Else if _targetLen_ is *-∞*<sub>𝔽</sub>, set _L_ to 0.
-              1. Else,
-                1. Let _targetLenAsInt_ be ! ToIntegerOrInfinity(_targetLen_).
-                1. Assert: _targetLenAsInt_ is finite.
-                1. Set _L_ to _targetLenAsInt_.
-          1. Perform SetFunctionLength(_F_, _L_).
-          1. Let _targetName_ be ? Get(_target_, *"name"*).
-          1. If _targetName_ is not a String, set _targetName_ to the empty String.
-          1. Perform SetFunctionName(_F_, _targetName_, *"wrapped"*).
-          1. Return _F_.
+          1. Let _asyncSnapshot_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncSnapshot.prototype%"*, « [[AsyncSnapshotMapping]] »).
+          1. Set _asyncSnapshot_.[[AsyncSnapshotMapping]] to _snapshot_.
+          1. Return _asyncSnapshot_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-properties-of-the-asynccontext-prototype-object">
-      <h1>Properties of the AsyncContext Prototype Object</h1>
-      <p>The <dfn>AsyncContext prototype object</dfn>:</p>
+    <emu-clause id="sec-properties-of-the-asyncsnapshot-prototype-object">
+      <h1>Properties of the AsyncSnapshot Prototype Object</h1>
+      <p>The <dfn>AsyncSnapshot prototype object</dfn>:</p>
       <ul>
-        <li>is <dfn>%AsyncContext.prototype%</dfn>.</li>
+        <li>is <dfn>%AsyncSnapshot.prototype%</dfn>.</li>
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is an ordinary object.</li>
-        <li>does not have any of the other internal slots of AsyncContext instances.</li>
+        <li>does not have any of the other internal slots of AsyncSnapshot instances.</li>
       </ul>
 
-      <emu-clause id="sec-asynccontext.prototype.run">
-        <h1>AsyncContext.prototype.run ( _value_, _func_, ..._args_ )</h1>
+      <emu-clause id="sec-asyncsnapshot.prototype.run">
+        <h1>AsyncSnapshot.prototype.run ( _func_, ..._args_ )</h1>
         <p>This method performs the following steps when called:</p>
         <emu-alg>
-          1. Let _asyncContext_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_asyncContext_, [[AsyncContextKey]]).
-          1. Let _asyncContextKey_ be _asyncContext_.[[AsyncContextKey]].
-          1. Let _previousContextMapping_ be AsyncContextSnapshot().
-          1. Let _asyncContextMapping_ be a new empty List.
-          1. For each Record { [[AsyncContextKey]], [[AsyncContextValue]] } _p_ of _previousContextMapping_, do
-            1. If SameValueZero(_p_.[[AsyncContextKey]], _asyncContextKey_) is *false*, then
-              1. Let _q_ be the Record { [[AsyncContextKey]]: _p_.[[AsyncContextKey]], [[AsyncContextValue]]: _p_.[[AsyncContextValue]] }.
-              1. Append _q_ to _asyncContextMapping_.
-          1. Assert: _asyncContextMapping_ does not contain a Record whose [[AsyncContextKey]] is _asyncContextKey_.
-          1. Let _p_ be the Record { [[AsyncContextKey]]: _asyncContextKey_, [[AsyncContextValue]]: _value_ }.
-          1. Append _p_ to _asyncContextMapping_.
-          1. AsyncContextSwap(_asyncContextMapping_).
+          1. Let _asyncSnapshot_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_asyncSnapshot_, [[AsyncSnapshotMapping]]).
+          1. Let _snapshot_ be _asyncSnapshot_.[[AsyncSnapshotMapping]].
+          1. Let _contextMapping_ be AsyncContextSnapshot().
+          1. AsyncContextSwap(_snapshot_).
           1. Let _result_ be Completion(Call(_func_, *undefined*, _args_)).
-          1. AsyncContextSwap(_previousContextMapping_).
+          1. AsyncContextSwap(_contextMapping_).
           1. Return _result_.
         </emu-alg>
       </emu-clause>
-
-      <emu-clause id="sec-asynccontext.prototype.get">
-        <h1>AsyncContext.prototype.get ( )</h1>
-        <p>This method performs the following steps when called:</p>
-        <emu-alg>
-          1. Let _asyncContext_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_asyncContext_, [[AsyncContextKey]]).
-          1. Let _agentRecord_ be the surrounding agent's Agent Record.
-          1. Let _asyncContextMapping_ be _agentRecord_.[[AsyncContextMapping]].
-          1. For each Record { [[AsyncContextKey]], [[AsyncContextValue]] } _p_ of _asyncContextMapping_, do
-            1. If SameValueZero(_p_.[[AsyncContextKey]], _asyncContext_.[[AsyncContextKey]]) is *true*, return _p_.[[AsyncContextValue]].
-          1. Return _asyncContext_.[[AsyncContextDefaultValue]].
-        </emu-alg>
-      </emu-clause>
     </emu-clause>
 
-    <emu-clause id="sec-asynccontext.prototype.name">
-      <h1>get AsyncContext.prototype.name</h1>
-      <p>`AsyncContext.prototype.name` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
-      <emu-alg>
-        1. Let _asyncContext_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_asyncContext_, [[AsyncContextKey]]).
-        1. Let _asyncContextKey_ be _asyncContext_.[[AsyncContextKey]].
-        1. Assert: _asyncContextKey_ is a Symbol.
-        1. Return _asyncContextKey_.[[Description]].
-      </emu-alg>
-    </emu-clause>
+    <emu-clause id="sec-properties-of-asyncsnapshot-instances">
+      <h1>Properties of AsyncSnapshot Instances</h1>
+      <p>AsyncSnapshot instances are ordinary objects that inherit properties from the AsyncSnapshot prototype object (the intrinsic, %AsyncSnapshot.prototype%). AsyncSnapshot instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-asyncsnapshot-instances"></emu-xref>.</p>
 
-    <emu-clause id="sec-properties-of-asynccontext-instances">
-      <h1>Properties of AsyncContext Instances</h1>
-      <p>AsyncContext instances are ordinary objects that inherit properties from the AsyncContext prototype object (the intrinsic, %AsyncContext.prototype%). AsyncContext instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-asynccontext-instances"></emu-xref>.</p>
-
-      <emu-table id="table-internal-slots-of-asynccontext-instances" caption="Internal Slots of AsyncContext Instances">
+      <emu-table id="table-internal-slots-of-asyncsnapshot-instances" caption="Internal Slots of AsyncSnapshot Instances">
         <table>
           <tr>
             <th>
@@ -507,24 +301,152 @@ contributors: Chengzhong Wu, Justin Ridgewell
           </tr>
           <tr>
             <td>
-              [[AsyncContextKey]]
+              [[AsyncSnapshotMapping]]
+            </td>
+            <td>
+              a List of Records with fields [[AsyncLocalKey]] (a Symbol) and [[AsyncLocalValue]] (an ECMAScript language value)
+            </td>
+            <td>
+              Represents the snapshotted surrounding agent's Agent Record's [[AsyncContextMapping]] of the AsyncSnapshot instance.
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-asynclocal-objects">
+    <h1>AsyncLocal Objects</h1>
+
+    <emu-clause id="sec-asynclocal-constructor">
+      <h1>The AsyncLocal Constructor</h1>
+      <p>The AsyncLocal constructor:</p>
+      <ul>
+        <li>is <dfn>%AsyncLocal%</dfn>.</li>
+        <li>is the initial value of the *"AsyncLocal"* property of the global object.</li>
+        <li>creates and initializes a new AsyncLocal when called as a constructor.</li>
+        <li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
+        <li>may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AsyncLocal behaviour must include a `super` call to the AsyncLocal constructor to create and initialize the subclass instance with the internal state necessary to support the `AsyncLocal` and `AsyncLocal.prototype` built-in methods.</li>
+      </ul>
+
+      <emu-clause id="sec-asynclocal">
+        <h1>AsyncLocal ( _options_ )</h1>
+        <p>This function performs the following steps when called:</p>
+
+        <emu-alg>
+          1. If NewTarget is *undefined*, throw a *TypeError* exception.
+          1. If _options_ is an Object, then
+            1. Let _name_ be ? Get(_options_, *"name"*).
+            1. Let _nameStr_ be ? ToString(_name_).
+            1. Let _defaultValue_ be ? Get(_options_, *"defaultValue"*).
+          1. Else,
+            1. Let _nameStr_ be the empty String.
+            1. Let _defaultValue_ be *undefined*.
+          1. Let _asyncLocal_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncLocal.prototype%"*, « [[AsyncLocalKey]], [[AsyncLocalDefaultValue]] »).
+          1. Set _asyncLocal_.[[AsyncLocalKey]] to a new Symbol whose [[Description]] is _nameStr_.
+          1. Set _asyncLocal_.[[AsyncLocalDefaultValue]] to _defaultValue_.
+          1. Return _asyncLocal_.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-the-asynclocal-prototype-object">
+      <h1>Properties of the AsyncLocal Prototype Object</h1>
+      <p>The <dfn>AsyncLocal prototype object</dfn>:</p>
+      <ul>
+        <li>is <dfn>%AsyncLocal.prototype%</dfn>.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
+        <li>is an ordinary object.</li>
+        <li>does not have any of the other internal slots of AsyncLocal instances.</li>
+      </ul>
+
+      <emu-clause id="sec-asynclocal.prototype.run">
+        <h1>AsyncLocal.prototype.run ( _value_, _func_, ..._args_ )</h1>
+        <p>This method performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _asyncLocal_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalKey]]).
+          1. Let _AsyncLocalKey_ be _asyncLocal_.[[AsyncLocalKey]].
+          1. Let _previousContextMapping_ be AsyncContextSnapshot().
+          1. Let _asyncContextMapping_ be a new empty List.
+          1. For each Record { [[AsyncLocalKey]], [[AsyncLocalValue]] } _p_ of _previousContextMapping_, do
+            1. If SameValueZero(_p_.[[AsyncLocalKey]], _AsyncLocalKey_) is *false*, then
+              1. Let _q_ be the Record { [[AsyncLocalKey]]: _p_.[[AsyncLocalKey]], [[AsyncLocalValue]]: _p_.[[AsyncLocalValue]] }.
+              1. Append _q_ to _asyncContextMapping_.
+          1. Assert: _asyncContextMapping_ does not contain a Record whose [[AsyncLocalKey]] is _AsyncLocalKey_.
+          1. Let _p_ be the Record { [[AsyncLocalKey]]: _AsyncLocalKey_, [[AsyncLocalValue]]: _value_ }.
+          1. Append _p_ to _asyncContextMapping_.
+          1. AsyncContextSwap(_asyncContextMapping_).
+          1. Let _result_ be Completion(Call(_func_, *undefined*, _args_)).
+          1. AsyncContextSwap(_previousContextMapping_).
+          1. Return _result_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asynclocal.prototype.name">
+        <h1>get AsyncLocal.prototype.name</h1>
+        <p>`AsyncLocal.prototype.name` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _asyncLocal_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalKey]]).
+          1. Let _asyncLocalKey_ be _asyncLocal_.[[AsyncLocalKey]].
+          1. Assert: _asyncLocalKey_ is a Symbol.
+          1. Return _asyncLocalKey_.[[Description]].
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asynclocal.prototype.get">
+        <h1>AsyncLocal.prototype.get ( )</h1>
+        <p>This method performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _asyncLocal_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_asyncLocal_, [[AsyncLocalKey]]).
+          1. Let _agentRecord_ be the surrounding agent's Agent Record.
+          1. Let _asyncContextMapping_ be _agentRecord_.[[AsyncContextMapping]].
+          1. For each Record { [[AsyncLocalKey]], [[AsyncLocalValue]] } _p_ of _asyncContextMapping_, do
+            1. If SameValueZero(_p_.[[AsyncLocalKey]], _asyncLocal_.[[AsyncLocalKey]]) is *true*, return _p_.[[AsyncLocalValue]].
+          1. Return _asyncLocal_.[[AsyncLocalDefaultValue]].
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-asynclocal-instances">
+      <h1>Properties of AsyncLocal Instances</h1>
+      <p>AsyncLocal instances are ordinary objects that inherit properties from the AsyncLocal prototype object (the intrinsic, %AsyncLocal.prototype%). AsyncLocal instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-asynclocal-instances"></emu-xref>.</p>
+
+      <emu-table id="table-internal-slots-of-asynclocal-instances" caption="Internal Slots of AsyncLocal Instances">
+        <table>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Type
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[AsyncLocalKey]]
             </td>
             <td>
               a Symbol
             </td>
             <td>
-              Represents the AsyncContext instance in the surrounding agent's Agent Record's [[AsyncContextMapping]].
+              Represents the AsyncLocal instance in the surrounding agent's Agent Record's [[AsyncContextMapping]].
             </td>
           </tr>
           <tr>
             <td>
-              [[AsyncContextDefaultValue]]
+              [[AsyncLocalDefaultValue]]
             </td>
             <td>
               an ECMAScript language value
             </td>
             <td>
-              The default value of the AsyncContext instance when no entry is found in the mapping.
+              The default value of the AsyncLocal instance when no entry is found in the mapping.
             </td>
           </tr>
         </table>


### PR DESCRIPTION
To distinguish the abstraction around the global state and local state, replace the built-in class `AsyncContext` with `AsyncContext.Snapshot` and `AsyncContext.Variable`.

Fixes: https://github.com/tc39/proposal-async-context/issues/44
Fixes: https://github.com/tc39/proposal-async-context/issues/36
Fixes: https://github.com/tc39/proposal-async-context/issues/21
