### PR TITLE
Add `CreateAsyncContextSnapshot` AO

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -968,6 +968,23 @@ contributors: Chengzhong Wu, Justin Ridgewell
           1. Return _asyncContextMapping_.
         </emu-alg>
       </emu-clause>
+
+      <emu-clause id="sec-createasynccontextsnapshot" type="abstract operation">
+        <h1>
+          CreateAsyncContextSnapshot (
+            _snapshotMapping_: a List of Async Context Mapping Records
+          ): either a normal completion containing an AsyncContext.Snapshot object or a throw completion
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It is used to obtain an AsyncContext.Snapshot object representing the given List of Async Context Mapping Records.</dd>
+        </dl>
+        <emu-alg>
+          1. Let _asyncSnapshot_ be ? OrdinaryCreateFromConstructor(%AsyncContext.Snapshot%, *"%AsyncContext.Snapshot.prototype%"*, « [[AsyncSnapshotMapping]] »).
+          1. Set _asyncSnapshot_.[[AsyncSnapshotMapping]] to _snapshotMapping_.
+          1. Return _asyncSnapshot_.
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-constructor-properties-of-the-asynccontext-object">

--- a/spec.html
+++ b/spec.html
@@ -984,6 +984,9 @@ contributors: Chengzhong Wu, Justin Ridgewell
           1. Set _asyncSnapshot_.[[AsyncSnapshotMapping]] to _snapshotMapping_.
           1. Return _asyncSnapshot_.
         </emu-alg>
+        <emu-note>
+          <p>This abstract operation is meant for hosts to use, and it is not used in this specification.</p>
+        </emu-note>
       </emu-clause>
     </emu-clause>
 


### PR DESCRIPTION
In the web integration of AsyncContext, web specs will need to create `AsyncContext.Snapshot` objects from an AsyncContext mapping; and we expect this to be necessary for other kinds of hosts as well, such as Node.js.

Currently the spec text does not provide any way to do that other than manually creating the object and populating its
`[[AsyncContextMapping]]` slot, since the `AsyncContext.Snapshot` constructor always uses the current mapping. So this patch adds an abstract operation called `CreateAsyncContextSnapshot` that provides this capability.