### PR TITLE
Handle the FinalizationRegistry's context in `HostEnqueueFinalizationRegistryCleanupJob`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -130,28 +130,31 @@ contributors: Chengzhong Wu, Justin Ridgewell
     </emu-table>
   </emu-clause>
 
-  <emu-clause id="sec-cleanup-finalization-registry" type="abstract operation">
-    <h1>
-      CleanupFinalizationRegistry (
-        _finalizationRegistry_: a FinalizationRegistry,
-      ): either a normal completion containing ~unused~ or a throw completion
-    </h1>
-    <dl class="header">
-    </dl>
-    <emu-alg>
-      1. <del>Assert: _finalizationRegistry_ has [[Cells]] and [[CleanupCallback]] internal slots.</del>
-      1. <ins>Assert: _finalizationRegistry_ has [[Cells]], [[CleanupCallback]], and [[FinalizationRegistryAsyncContextMapping]] internal slots.</ins>
-      1. Let _callback_ be _finalizationRegistry_.[[CleanupCallback]].
-      1. While _finalizationRegistry_.[[Cells]] contains a Record _cell_ such that _cell_.[[WeakRefTarget]] is ~empty~, an implementation may perform the following steps:
-        1. Choose any such _cell_.
-        1. Remove _cell_ from _finalizationRegistry_.[[Cells]].
-        1. <del>Perform ? HostCallJobCallback(_callback_, *undefined*, « _cell_.[[HeldValue]] »).</del>
-        1. <ins>Let _previousContextMapping_ be AsyncContextSwap(_finalizationRegistry_.[[FinalizationRegistryAsyncContextMapping]]).</ins>
-        1. <ins>Let _result_ be Completion(HostCallJobCallback(_callback_, *undefined*, « _cell_.[[HeldValue]] »)).</ins>
-        1. <ins>AsyncContextSwap(_previousContextMapping_).</ins>
-        1. <ins>Perform ? _result_.</ins>
-      1. Return ~unused~.
-    </emu-alg>
+  <emu-clause id="sec-weakref-processing-model">
+    <h1>Processing Model of WeakRef and FinalizationRegistry Targets</h1>
+
+    <emu-clause id="sec-weakref-host-hooks">
+      <h1>Host Hooks</h1>
+
+      <emu-clause id="sec-host-cleanup-finalization-registry" type="host-defined abstract operation">
+        <h1>
+          HostEnqueueFinalizationRegistryCleanupJob (
+            _finalizationRegistry_: a FinalizationRegistry,
+          ): ~unused~
+        </h1>
+        <dl class="header">
+        </dl>
+        <p>Let _cleanupJob_ be a new Job Abstract Closure with no parameters that captures _finalizationRegistry_ and performs the following steps when called:</p>
+        <emu-alg>
+          1. <ins>Let _previousContextMapping_ be AsyncContextSwap(_finalizationRegistry_.[[FinalizationRegistryAsyncContextMapping]]).</ins>
+          1. Let _cleanupResult_ be Completion(CleanupFinalizationRegistry(_finalizationRegistry_)).
+          1. If _cleanupResult_ is an abrupt completion, perform any host-defined steps for reporting the error.
+          1. <ins>AsyncContextSwap(_previousContextMapping_).</ins>
+          1. Return ~unused~.
+        </emu-alg>
+        <p>An implementation of HostEnqueueFinalizationRegistryCleanupJob schedules _cleanupJob_ to be performed at some future time, if possible. It must also conform to the requirements in <emu-xref href="#sec-jobs"></emu-xref>.</p>
+      </emu-clause>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 


### PR DESCRIPTION
Each FinalizationRegistry object has a context associated with it, which was the context at its construction. This context is used for calling its callback when any registered object is GC'd, which takes place in the `CleanupFinalizationRegistry` AO.

In the current spec, `CleanupFinalizationRegistry` handles the swapping of this context, and restores it back at the end. This, however, causes a problem for hosts that report uncaught JS exceptions by running JS code (such as the `"error"` event on `window` in the web, or the `"unhandledException"` event on `process` in Node.js), since they should run this event in the FinalizationRegistry's creation context, but `CleanupFinalizationRegistry` exits that context before the end of the function.

Since `CleanupFinalizationRegistry` (and `HostEnqueueFinalizationRegistryCleanupJob`) only clean up a single FinalizationRegitry, however, the context swapping can be pushed to the host hook instead, with the step about host-defined error reporting being inside that context. This ensures that such error reporting events are fired in the right context.