### PR TITLE
Clarify a bit web integration document

### DIFF
--- a/WEB-INTEGRATION.md
+++ b/WEB-INTEGRATION.md
@@ -801,7 +801,7 @@ steps _steps_, would do the following:
 >    1. Throw _e_.
 > 1. [AsyncContextSwap](https://tc39.es/proposal-async-context/#sec-asynccontextswap)(_previousContext_).
 
-For web APIs that use that take a callback and eventually call it with the same context as when
+For web APIs that take a callback and eventually call it with the same context as when
 the web API was called, this should be handled in WebIDL by storing the result of `AsyncContextSnapshot()`
 alongside the callback function, and swapping it when the function is called. Since this should not happen
 for every callback, there should be a WebIDL extended attribute applied to callback types to control this.

--- a/WEB-INTEGRATION.md
+++ b/WEB-INTEGRATION.md
@@ -803,11 +803,10 @@ steps _steps_, would do the following:
 >    1. Throw _e_.
 > 1. [AsyncContextSwap](https://tc39.es/proposal-async-context/#sec-asynccontextswap)(_previousContext_).
 
-For web APIs that use the registration context and take a callback, this should
-be handled in WebIDL by storing the result of `AsyncContextSnapshot()` alongside
-the callback function, and swapping it when the function is called. Since this
-should not happen for every callback, there should be a WebIDL extended
-attribute applied to callback types to control this.
+For web APIs that use that take a callback and eventually call it with the same context as when
+the web API was called, this should be handled in WebIDL by storing the result of `AsyncContextSnapshot()`
+alongside the callback function, and swapping it when the function is called. Since this should not happen
+for every callback, there should be a WebIDL extended attribute applied to callback types to control this.
 
 ## Implicit context propagation
 

--- a/WEB-INTEGRATION.md
+++ b/WEB-INTEGRATION.md
@@ -301,7 +301,7 @@ Event dispatches can be one of the following:
   or browser engines.
 - **Browser-originated dispatches**, where the event is triggered by browser or
   user actions, or by cross-agent JS, with no involvement from JS code in the
-  same agent. Such dispatches can't have propagate any context from some non-existing
+  same agent. Such dispatches can't have propagated any context from some non-existing
   JS code that triggerted them, so the listener is called with the empty context.
   (Though see the section on fallback context below.)
 - **Asynchronous dispatches**, where the event originates from JS calling into

--- a/WEB-INTEGRATION.md
+++ b/WEB-INTEGRATION.md
@@ -377,9 +377,9 @@ called once per observation. Instead, multiple observations can be batched into
 one single call. This means that there is not always a single JS action that causes
 some work that eventually triggers the observer callback; rather, there might be many.
 
-Given this, for consistency it would be preferable to instead propagate the context that
-was active when the observer callback was registered; that is, the context in which the
-class is constructed.
+Given this, observer callbacks should always run with the empty context. This can be explained
+by saying that layout changes are always considered to be a browser-internal trigger, even if
+they were caused by changes injected into the DOM or styles through JavaScript.
 
 - [`MutationObserver`](https://dom.spec.whatwg.org/#mutationobserver)
   [\[DOM\]](https://dom.spec.whatwg.org/)
@@ -392,12 +392,12 @@ class is constructed.
 - [`ReportingObserver`](https://w3c.github.io/reporting/#reportingobserver)
   [\[REPORTING\]](https://w3c.github.io/reporting/)
 
-> [!IMPORTANT]
-> Due to concerns about observers leading to memory leaks, an alternative
-> option is to not use the context from when the observer was created, and instead call the observer's
-> callback with the empty context. This is coherent with the general design direction
-> of using the dispatch context, except that we would say that these observers are always
-> triggered as consequences of browser-internal code.
+> [!NOTE]
+> An older version of this proposal suggested to capture the context at the time the observer
+> is create, and use it to run the callback. This has been removed due to memory leak concerns.
+>
+> It's under discussion wether observers should use the same mechanism as events (see below)
+> to define a scoped fallback value for some `AsyncContext.Variable`s.
 
 In some cases it might be useful to expose the causal context for individual
 observations, by exposing an `AsyncContext.Snapshot` property on the observation

--- a/WEB-INTEGRATION.md
+++ b/WEB-INTEGRATION.md
@@ -327,8 +327,6 @@ context where each `AsyncContext.Variable` is set to its initial value:
   form would queue a microtask to call its `formResetCallback` lifecycle hook,
   and there would not be a causal context.
 
-<!-- Is this still true? -->
-
 In the cases where the registration web API takes a constructor (such as
 worklets) rather than a callback, the registration-time context should be used,
 and any getters or methods of the constructed object that are called as a result

--- a/WEB-INTEGRATION.md
+++ b/WEB-INTEGRATION.md
@@ -605,7 +605,7 @@ that causes some work that eventually triggers the observer callback; rather, th
 
 Given this, observer callbacks should always run with the empty context, using the same
 [fallback context mechanism](#fallback-context-107) as for events. This can be explained
-by saying that layout changes are always considered to be a browser-internal trigger, even if
+by saying that, e.g. layout changes are always considered to be a browser-internal trigger, even if
 they were caused by changes injected into the DOM or styles through JavaScript.
 
 - [`MutationObserver`](https://dom.spec.whatwg.org/#mutationobserver)

--- a/WEB-INTEGRATION.md
+++ b/WEB-INTEGRATION.md
@@ -359,12 +359,9 @@ In general, the context that should be used is the one that matches the data
 flow through the algorithms ([see the section on implicit propagation
 below](#implicit-context-propagation)).
 
-<!-- Streams are largely defined on top of promises, and can be easily
-reimplemented in userland by copying the spec step-by-step. Likely this
-described propagation already properly comes out of that? -->
-
-> TODO: Piping is largely implementation-defined. We should figure out some
-> context propagation constraints.
+> TODO: Piping is largely implementation-defined. We will need to explicitly
+> define how propagation works there, rather than relying on the streams
+> usage of promises, to ensure interoperability.
 
 > TODO: If a stream gets transferred to a different agent, any cross-agent
 > interactions will have to use the empty context. What if you round-trip a

--- a/WEB-INTEGRATION.md
+++ b/WEB-INTEGRATION.md
@@ -128,14 +128,13 @@ Web frameworks such as React may decide to save and restore
 `AsyncContext.Snapshot`s when re-rendering subtrees. More outreach to frameworks
 is needed to confirm exactly how this will be used.
 
-
 ## General approach to web API semantics with AsyncContext
 
 The AsyncContext API isn’t designed to be used directly by most
-JavaScript application developers, but rather as an implementation detail of certain
-third-party libraries. AsyncContext makes it so users of those libraries don’t
-need to explicitly integrate with it. Instead, the AsyncContext mechanism
-handles implicitly passing contextual data around.
+JavaScript application developers, but rather used by certain third-party libraries
+to provide good DX to web developers. AsyncContext makes it so users
+of those libraries don’t need to explicitly integrate with it. Instead, the
+AsyncContext mechanism handles implicitly passing contextual data around.
 
 In general, contexts should propagate along an algorithm’s data flow. If an
 algorithm running in the event loop synchronously calls another algorithm or

--- a/WEB-INTEGRATION.md
+++ b/WEB-INTEGRATION.md
@@ -189,12 +189,10 @@ examine which context should be propagated.
 
 # Individual analysis of web APIs and AsyncContext
 
-## Web APIs that take callbacks
-
 For web APIs that take callbacks, the context in which the callback is run would
 depend on the kind of API:
 
-### Schedulers
+## Schedulers
 
 These are web APIs whose sole purpose is to take a callback and schedule it in
 the event loop in some way. The callback will run asynchronously at some point,
@@ -221,7 +219,7 @@ Examples of scheduler web APIs:
   [`requestVideoFrameCallback()`](https://wicg.github.io/video-rvfc/#dom-htmlvideoelement-requestvideoframecallback)
   method [\[VIDEO-RVFC\]](https://wicg.github.io/video-rvfc/)
 
-### Async completion callbacks
+## Async completion callbacks
 
 These web APIs start an asynchronous operation, and take callbacks to indicate
 that the operation has completed. These are usually legacy APIs, since modern
@@ -253,7 +251,7 @@ and then they were changed to return a promise – e.g. `BaseAudioContext`’s
 similarly to other async completion callbacks, and the promise rejection context
 would behave similarly to other promise-returning web APIs (see below).
 
-#### Callbacks run as part of an async algorithm
+### Callbacks run as part of an async algorithm
 
 These APIs always invoke the callback to run user code as part of an
 asynchronous operation that they start, and which affects the behavior of the
@@ -535,7 +533,7 @@ answered:
   which can run when triggered from outside of JavaScript? (e.g. observers)
 - should it be a global, or a static method of `EventTarget`?
 
-### Status change listener callbacks
+## Status change listener callbacks
 
 These APIs register a callback or constructor to be invoked when some action
 runs. They’re also commonly used as a way to associate a newly created class
@@ -556,7 +554,7 @@ example, `navigator.geolocation.watchPosition(cb)` propagate the same way as
   [`watchAvailability()`](https://w3c.github.io/remote-playback/#dom-remoteplayback-watchavailability)
   method [\[REMOTE-PLAYBACK\]](https://w3c.github.io/remote-playback/)
 
-#### Worklets
+### Worklets
 
 Worklets work similarly: you provide a class to an API that is called
 _always from outside of the worklet thread_ when there is some work to be done.
@@ -570,7 +568,7 @@ calling those methods), in practice that context will always match the root cont
 worklet scope (because `register*()` is always called at the top-level). Hence, to simplify
 implementations we propose that Worklet methods always run in the root context.
 
-#### Custom elements
+### Custom elements
 
 Custom elements are also registered by passing a class to a web API, and this class
 has some methods that are called at different points of the custom element's lifecycle.
@@ -594,8 +592,7 @@ context to propagate:
 Similarly to events, in this case lifecycle callbacks would run in the empty context, with
 the [fallback context mechanism](#fallback-context-107).
 
-
-### Observers
+## Observers
 
 Observers are a kind of web API pattern where the constructor for a class takes
 a callback, the instance’s `observe()` method is called to register things that
@@ -633,7 +630,7 @@ record. This should be the case for `PerformanceObserver`, where
 is not included as part of this initial proposed version, as new properties can
 easily be added as follow-ups in the future.
 
-### Stream underlying APIs
+## Stream underlying APIs
 
 The underlying [source](https://streams.spec.whatwg.org/#underlying-source-api),
 [sink](https://streams.spec.whatwg.org/#underlying-sink-api) and


### PR DESCRIPTION
I was reading through the web integration doc again, and changed some parts to highlight more the core design aspects and the reason behind them. Importantly, I added the same observations that there are in the slides for the upcoming TC39 meeting:
- the proposed behavior matches what you would usually get from userland implementations
- in many cases there is no difference between dispatch and causal contexts.

I also changed the note about Observers, marking that as Important using GitHub's syntax (https://github.com/orgs/community/discussions/16925), explaining why going through the always-empty-context path can be explained as coherent.